### PR TITLE
Hide deleted_at column from API responses

### DIFF
--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -55,6 +55,7 @@ class SeedRank extends Model
     protected $hidden = [
         'created_at',
         'updated_at',
+        'deleted_at',
     ];
 
     /**

--- a/tests/Unit/Models/SeedRankTest.php
+++ b/tests/Unit/Models/SeedRankTest.php
@@ -44,6 +44,14 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
+    public function it_hides_the_deleted_at_field_from_the_output()
+    {
+        $seedRank = new SeedRank();
+
+        $this->assertContains('deleted_at', $seedRank->getHidden());
+    }
+
+    /** @test */
     public function it_casts_the_rank_column_to_a_string()
     {
         $seedRank = new SeedRank();


### PR DESCRIPTION
Remove `deleted_at` column from API responses.