### PR TITLE
Code cleanup

### DIFF
--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -54,6 +54,16 @@ class Element extends Model
     protected $orderByDirection = 'asc';
 
     /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'name',
+    ];
+
+    /**
      * The attributes that should be hidden for arrays.
      *
      * @var array $hidden

--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -80,6 +80,7 @@ class Element extends Model
      * @var array $casts
      */
     protected $casts = [
+        'id' => 'string',
         'name' => 'string',
     ];
 

--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -19,6 +19,13 @@ class Element extends Model
     protected $table = 'elements';
 
     /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool

--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -92,4 +92,14 @@ class Element extends Model
     protected $filterableFields = [
         'name',
     ];
+
+    /**
+     * The operators that are explicitly enabled for filtering.
+     *
+     * @return array
+     */
+    protected $filterableOperators = [
+        'like' => 'like',
+        'not' => '<>',
+    ];
 }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -19,7 +19,7 @@ class Location extends Model
     protected $table = 'locations';
 
     /**
-     * The "type" of the primary key ID.
+     * The 'type' of the primary key ID.
      *
      * @var string
      */

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -82,6 +82,7 @@ class SeedRank extends Model
      * @var array $casts
      */
     protected $casts = [
+        'id' => 'string',
         'rank' => 'string',
         'salary' => 'integer',
     ];

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -20,6 +20,13 @@ class SeedRank extends Model
     protected $table = 'seed_ranks';
 
     /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -55,6 +55,17 @@ class SeedRank extends Model
     protected $orderByDirection = 'asc';
 
     /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'rank',
+        'salary',
+    ];
+
+    /**
      * The attributes that should be hidden for arrays.
      *
      * @var array $hidden

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -96,4 +96,18 @@ class SeedRank extends Model
         'rank',
         'salary',
     ];
+
+    /**
+     * The operators that are explicitly enabled for filtering.
+     *
+     * @return array
+     */
+    protected $filterableOperators = [
+        'lt' => '<',
+        'lte' => '<=',
+        'gt' => '>',
+        'gte' => '>=',
+        'like' => 'like',
+        'not' => '<>',
+    ];
 }

--- a/database/seeds/ElementsTableSeeder.php
+++ b/database/seeds/ElementsTableSeeder.php
@@ -3,6 +3,7 @@
 use App\Models\Element;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
 
 class ElementsTableSeeder extends Seeder
 {

--- a/database/seeds/SeedRanksTableSeeder.php
+++ b/database/seeds/SeedRanksTableSeeder.php
@@ -2,6 +2,7 @@
 
 use App\Models\SeedRank;
 use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
 
 class SeedRanksTableSeeder extends Seeder
 {

--- a/tests/Feature/Routes/ElementRoutesTest.php
+++ b/tests/Feature/Routes/ElementRoutesTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Routes;
 
 use App\Models\Element;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class ElementRoutesTest extends TestCase
@@ -40,7 +39,7 @@ class ElementRoutesTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $response = $this->get("/api/elements?name=like:er:w");
+        $response = $this->get('/api/elements?name=like:er:w');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -55,7 +54,7 @@ class ElementRoutesTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $response = $this->get("/api/elements?name=thunder");
+        $response = $this->get('/api/elements?name=thunder');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -69,7 +68,7 @@ class ElementRoutesTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $response = $this->get("/api/elements?name=like:er");
+        $response = $this->get('/api/elements?name=like:er');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -84,7 +83,7 @@ class ElementRoutesTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $response = $this->get("/api/elements?name=not:water");
+        $response = $this->get('/api/elements?name=not:water');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Routes;
 
 use App\Models\Location;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class LocationRoutesTest extends TestCase
@@ -40,7 +39,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $response = $this->get("/api/locations?name=like:al:0");
+        $response = $this->get('/api/locations?name=like:al:0');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -55,7 +54,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $response = $this->get("/api/locations?name=Balamb Region");
+        $response = $this->get('/api/locations?name=Balamb Region');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -69,7 +68,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $response = $this->get("/api/locations?name=like:al");
+        $response = $this->get('/api/locations?name=like:al');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -84,7 +83,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $response = $this->get("/api/locations?name=not:Balamb Region");
+        $response = $this->get('/api/locations?name=not:Balamb Region');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -99,7 +98,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
         factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
-        $response = $this->get("/api/locations?area=Alcauld Plains");
+        $response = $this->get('/api/locations?area=Alcauld Plains');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -113,7 +112,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
         factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
-        $response = $this->get("/api/locations?area=like:Plains");
+        $response = $this->get('/api/locations?area=like:Plains');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -128,7 +127,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
         factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
-        $response = $this->get("/api/locations?area=not:Alcauld Plains");
+        $response = $this->get('/api/locations?area=not:Alcauld Plains');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -143,7 +142,7 @@ class LocationRoutesTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Garden', 'area' => 'Monterosa Plateau' ]);
         factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
-        $response = $this->get("/api/locations?name=like:Garden&area=not:Alcauld Plains");
+        $response = $this->get('/api/locations?name=like:Garden&area=not:Alcauld Plains');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -168,8 +167,7 @@ class LocationRoutesTest extends TestCase
             'area' => 'Alcauld Plains',
         ]);
 
-        
-        $response = $this->get("/api/locations?with=region");
+        $response = $this->get('/api/locations?with=region');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -193,7 +191,7 @@ class LocationRoutesTest extends TestCase
             'area' => 'Alcauld Plains',
         ]);
 
-        $response = $this->get("/api/locations?with=region&name=like:Garden");
+        $response = $this->get('/api/locations?with=region&name=like:Garden');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -217,7 +215,7 @@ class LocationRoutesTest extends TestCase
             'area' => 'Alcauld Plains',
         ]);
 
-        $response = $this->get("/api/locations?with=region.name&name=like:garden");
+        $response = $this->get('/api/locations?with=region.name&name=like:garden');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -244,7 +242,7 @@ class LocationRoutesTest extends TestCase
             'area' => 'Alcauld Plains',
         ]);
 
-        $response = $this->get("/api/locations?with=region.name,region.area&name=like:garden");
+        $response = $this->get('/api/locations?with=region.name,region.area&name=like:garden');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -228,7 +228,7 @@ class LocationRoutesTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_multiple_columns_explicitly()
+    public function it_can_load_multiple_relation_columns_explicitly()
     {
         $balambRegion = factory(Location::class)->create([ 
             'name' => 'Balamb Region', 

--- a/tests/Feature/Routes/SeedRankRoutesTest.php
+++ b/tests/Feature/Routes/SeedRankRoutesTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Routes;
 
 use App\Models\SeedRank;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class SeedRankRoutesTest extends TestCase
@@ -40,7 +39,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=like:1:0");
+        $response = $this->get('/api/seed-ranks?rank=like:1:0');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -55,7 +54,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=5");
+        $response = $this->get('/api/seed-ranks?rank=5');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -69,7 +68,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=gt:5");
+        $response = $this->get('/api/seed-ranks?rank=gt:5');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -83,7 +82,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=gte:5");
+        $response = $this->get('/api/seed-ranks?rank=gte:5');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -98,7 +97,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=lt:5");
+        $response = $this->get('/api/seed-ranks?rank=lt:5');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -112,7 +111,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=lte:5");
+        $response = $this->get('/api/seed-ranks?rank=lte:5');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -127,7 +126,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=like:1");
+        $response = $this->get('/api/seed-ranks?rank=like:1');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -142,7 +141,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $response = $this->get("/api/seed-ranks?rank=not:10");
+        $response = $this->get('/api/seed-ranks?rank=not:10');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -157,7 +156,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=3000");
+        $response = $this->get('/api/seed-ranks?salary=3000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -171,7 +170,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=gt:3000");
+        $response = $this->get('/api/seed-ranks?salary=gt:3000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -185,7 +184,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=gte:3000");
+        $response = $this->get('/api/seed-ranks?salary=gte:3000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -200,7 +199,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=lt:3000");
+        $response = $this->get('/api/seed-ranks?salary=lt:3000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(1);
@@ -214,7 +213,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=lte:3000");
+        $response = $this->get('/api/seed-ranks?salary=lte:3000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -229,7 +228,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=like:000");
+        $response = $this->get('/api/seed-ranks?salary=like:000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -244,7 +243,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=not:3000");
+        $response = $this->get('/api/seed-ranks?salary=not:3000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);
@@ -259,7 +258,7 @@ class SeedRankRoutesTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $response = $this->get("/api/seed-ranks?salary=not:8000");
+        $response = $this->get('/api/seed-ranks?salary=not:8000');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2);

--- a/tests/Unit/Controllers/ElementControllerTest.php
+++ b/tests/Unit/Controllers/ElementControllerTest.php
@@ -64,6 +64,21 @@ class ElementControllerTest extends TestCase
     }
 
     /** @test */
+    public function the_filters_are_case_insensitive()
+    {
+        factory(Element::class)->create([ 'name' => 'fire' ]);
+        factory(Element::class)->create([ 'name' => 'water' ]);
+        factory(Element::class)->create([ 'name' => 'thunder' ]);
+
+        $request = new Request([ 'name' => 'FiRe' ]);
+        $elementController = new ElementController(new Element());
+        $response = $elementController->index($request);
+
+        $this->assertCount(1, $response);
+        $this->assertTrue($response->contains('name', 'fire'));
+    }
+
+    /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
         factory(Element::class)->create([ 'name' => 'fire' ]);

--- a/tests/Unit/Controllers/ElementControllerTest.php
+++ b/tests/Unit/Controllers/ElementControllerTest.php
@@ -54,7 +54,7 @@ class ElementControllerTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $request = new Request(['name' => 'like:er:w']);
+        $request = new Request([ 'name' => 'like:er:w' ]);
         $elementController = new ElementController($element);
         $response = $elementController->index($request);
 
@@ -70,7 +70,7 @@ class ElementControllerTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $request = new Request(['name' => 'thunder']);
+        $request = new Request([ 'name' => 'thunder' ]);
         $elementController = new ElementController(new Element());
         $response = $elementController->index($request);
 
@@ -85,7 +85,7 @@ class ElementControllerTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $request = new Request(['name' => 'like:er']);
+        $request = new Request([ 'name' => 'like:er' ]);
         $elementController = new ElementController(new Element());
         $response = $elementController->index($request);
 
@@ -101,7 +101,7 @@ class ElementControllerTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $request = new Request(['name' => 'not:water']);
+        $request = new Request([ 'name' => 'not:water' ]);
         $elementController = new ElementController(new Element());
         $response = $elementController->index($request);
 

--- a/tests/Unit/Controllers/ElementControllerTest.php
+++ b/tests/Unit/Controllers/ElementControllerTest.php
@@ -54,7 +54,7 @@ class ElementControllerTest extends TestCase
         factory(Element::class)->create([ 'name' => 'water' ]);
         factory(Element::class)->create([ 'name' => 'thunder' ]);
 
-        $request = new Request(['name' => "like:er:w"]);
+        $request = new Request(['name' => 'like:er:w']);
         $elementController = new ElementController($element);
         $response = $elementController->index($request);
 

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -274,7 +274,7 @@ class LocationControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_multiple_columns_explicitly()
+    public function it_can_load_multiple_relation_columns_explicitly()
     {
         $balambRegion = factory(Location::class)->create([ 
             'name' => 'Balamb Region', 

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -54,7 +54,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $request = new Request(['name' => 'like:al:w']);
+        $request = new Request([ 'name' => 'like:al:w' ]);
         $locationController = new LocationController($location);
         $response = $locationController->index($request);
 
@@ -70,7 +70,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $request = new Request(['name' => 'galbadia region']);
+        $request = new Request([ 'name' => 'galbadia region' ]);
         $locationController = new LocationController(new Location());
         $response = $locationController->index($request);
 
@@ -85,7 +85,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $request = new Request(['name' => 'Galbadia Region']);
+        $request = new Request([ 'name' => 'Galbadia Region' ]);
         $locationController = new LocationController(new Location());
         $response = $locationController->index($request);
 
@@ -100,7 +100,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar' ]);
 
-        $request = new Request(['name' => 'like:Region']);
+        $request = new Request([ 'name' => 'like:Region' ]);
         $locationController = new LocationController(new Location());
         $response = $locationController->index($request);
 
@@ -116,7 +116,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar' ]);
 
-        $request = new Request(['name' => 'not:Galbadia Region']);
+        $request = new Request([ 'name' => 'not:Galbadia Region' ]);
         $locationController = new LocationController(new Location());
         $response = $locationController->index($request);
 
@@ -147,7 +147,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
         factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
-        $request = new Request(['area' => 'like:Plains']);
+        $request = new Request([ 'area' => 'like:Plains' ]);
         $locationController = new LocationController(new Location());
         $response = $locationController->index($request);
 
@@ -163,7 +163,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
         factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
-        $request = new Request(['area' => 'not:Alcauld Plains']);
+        $request = new Request([ 'area' => 'not:Alcauld Plains' ]);
         $locationController = new LocationController(new Location());
         $response = $locationController->index($request);
 

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -54,7 +54,7 @@ class LocationControllerTest extends TestCase
         factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
         factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
 
-        $request = new Request(['name' => "like:al:w"]);
+        $request = new Request(['name' => 'like:al:w']);
         $locationController = new LocationController($location);
         $response = $locationController->index($request);
 

--- a/tests/Unit/Controllers/SeedRankControllerTest.php
+++ b/tests/Unit/Controllers/SeedRankControllerTest.php
@@ -48,13 +48,13 @@ class SeedRankControllerTest extends TestCase
     {
         // Set the filterable operators on the SeedRank class.
         $seedRank = new SeedRank();
-        $seedRank->filterableOperators = ['like' => 'like'];
+        $seedRank->filterableOperators = [ 'like' => 'like' ];
 
         factory(SeedRank::class)->create([ 'rank' => 1 ]);
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'like:1:0']);
+        $request = new Request([ 'rank' => 'like:1:0' ]);
         $seedRankController = new SeedRankController($seedRank);
         $response = $seedRankController->index($request);
 
@@ -70,7 +70,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 5]);
+        $request = new Request([ 'rank' => 5 ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -85,7 +85,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'gt:5']);
+        $request = new Request([ 'rank' => 'gt:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -100,7 +100,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'gte:5']);
+        $request = new Request([ 'rank' => 'gte:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -116,7 +116,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'lt:5']);
+        $request = new Request([ 'rank' => 'lt:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -131,7 +131,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'lte:5']);
+        $request = new Request([ 'rank' => 'lte:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -147,7 +147,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'like:1']);
+        $request = new Request([ 'rank' => 'like:1' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -163,7 +163,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => 'not:10']);
+        $request = new Request([ 'rank' => 'not:10' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -179,7 +179,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 500]);
+        $request = new Request([ 'salary' => 500 ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -194,7 +194,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 'gt:3000']);
+        $request = new Request([ 'salary' => 'gt:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -209,7 +209,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 'gte:3000']);
+        $request = new Request([ 'salary' => 'gte:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -225,7 +225,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 'lt:3000']);
+        $request = new Request([ 'salary' => 'lt:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -240,7 +240,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 'lte:3000']);
+        $request = new Request([ 'salary' => 'lte:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -256,7 +256,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 'like:000']);
+        $request = new Request([ 'salary' => 'like:000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 
@@ -272,7 +272,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
         factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
 
-        $request = new Request(['salary' => 'not:8000']);
+        $request = new Request([ 'salary' => 'not:8000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
         $response = $seedRankController->index($request);
 

--- a/tests/Unit/Controllers/SeedRankControllerTest.php
+++ b/tests/Unit/Controllers/SeedRankControllerTest.php
@@ -54,7 +54,7 @@ class SeedRankControllerTest extends TestCase
         factory(SeedRank::class)->create([ 'rank' => 5 ]);
         factory(SeedRank::class)->create([ 'rank' => 10 ]);
 
-        $request = new Request(['rank' => "like:1:0"]);
+        $request = new Request(['rank' => 'like:1:0']);
         $seedRankController = new SeedRankController($seedRank);
         $response = $seedRankController->index($request);
 

--- a/tests/Unit/Models/ElementTest.php
+++ b/tests/Unit/Models/ElementTest.php
@@ -5,7 +5,6 @@ namespace Tests\Unit\Models;
 use App\Models\Element;
 use App\Traits\Filterable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class ElementTest extends TestCase

--- a/tests/Unit/Models/ElementTest.php
+++ b/tests/Unit/Models/ElementTest.php
@@ -20,6 +20,14 @@ class ElementTest extends TestCase
     }
 
     /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $element = new Element();
+
+        $this->assertEquals('string', $element->getKeyType());
+    }
+
+    /** @test */
     public function it_does_not_allow_properties_to_be_assigned_in_mass()
     {
         $element = new Element();
@@ -28,27 +36,30 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_hides_the_created_at_field_from_the_output()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
     {
         $element = new Element();
 
-        $this->assertContains('created_at', $element->getHidden());
+        $visibleFields = [
+            'id',
+            'name',      
+        ];
+
+        $this->assertEquals($visibleFields, $element->getVisible());
     }
 
     /** @test */
-    public function it_hides_the_updated_at_field_from_the_output()
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
     {
         $element = new Element();
 
-        $this->assertContains('updated_at', $element->getHidden());
-    }
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',    
+        ];
 
-    /** @test */
-    public function it_hides_the_deleted_at_field_from_the_output()
-    {
-        $element = new Element();
-
-        $this->assertContains('deleted_at', $element->getHidden());
+        $this->assertEquals($hiddenFields, $element->getHidden());
     }
 
     /** @test */
@@ -80,4 +91,21 @@ class ElementTest extends TestCase
 
         $this->assertEquals($shouldBeFilterable, $element->getFilterableFields());
     }
+
+    /** @test */
+    public function it_orders_results_by_name()
+    {
+        $element = new Element();
+
+        $this->assertEquals('name', $element->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    {
+        $element = new Element();
+
+        $this->assertEquals('asc', $element->getOrderByDirection());
+    }
+
 }

--- a/tests/Unit/Models/LocationTest.php
+++ b/tests/Unit/Models/LocationTest.php
@@ -6,7 +6,6 @@ use App\Models\Location;
 use App\Traits\Filterable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class LocationTest extends TestCase

--- a/tests/Unit/Models/SeedRankTest.php
+++ b/tests/Unit/Models/SeedRankTest.php
@@ -20,6 +20,14 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $seedRank = new SeedRank();
+
+        $this->assertEquals('string', $seedRank->getKeyType());
+    }
+
+    /** @test */
     public function it_does_not_allow_properties_to_be_assigned_in_mass()
     {
         $seedRank = new SeedRank();
@@ -28,27 +36,31 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_hides_the_created_at_field_from_the_output()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
     {
         $seedRank = new SeedRank();
 
-        $this->assertContains('created_at', $seedRank->getHidden());
+        $visibleFields = [
+            'id',
+            'rank',
+            'salary',
+        ];
+
+        $this->assertEquals($visibleFields, $seedRank->getVisible());
     }
 
     /** @test */
-    public function it_hides_the_updated_at_field_from_the_output()
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
     {
         $seedRank = new SeedRank();
 
-        $this->assertContains('updated_at', $seedRank->getHidden());
-    }
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',    
+        ];
 
-    /** @test */
-    public function it_hides_the_deleted_at_field_from_the_output()
-    {
-        $seedRank = new SeedRank();
-
-        $this->assertContains('deleted_at', $seedRank->getHidden());
+        $this->assertEquals($hiddenFields, $seedRank->getHidden());
     }
 
     /** @test */
@@ -72,18 +84,6 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_stores_a_seed_rank_in_the_database()
-    {
-        $seedRank = factory(SeedRank::class)->make();
-
-        $seedRank->save();
-
-        $this->assertDatabaseHas('seed_ranks', [
-            'id' => $seedRank->id,
-        ]);
-    }
-
-    /** @test */
     public function it_is_able_to_filter_records()
     {
         $this->assertTrue(in_array(
@@ -102,5 +102,21 @@ class SeedRankTest extends TestCase
         ];
 
         $this->assertEquals($shouldBeFilterable, $seedRank->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_orders_results_by_salary()
+    {
+        $seedRank = new SeedRank();
+
+        $this->assertEquals('salary', $seedRank->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    {
+        $seedRank = new SeedRank();
+
+        $this->assertEquals('asc', $seedRank->getOrderByDirection());
     }
 }


### PR DESCRIPTION
This PR is a general cleanup of the codebase. Changes are as follows:

* Single quotes have replaced double quotes where applicable.
* Unused class imports have been removed.
* Array spacing has been standardized to include spaces before and after the elements in the array when on a simple line (`[ key => value ]`).
* `keyType` has been updated on all models to specify `string` as the target type. This fixes issues with retrieving records from the database.
* Attributes that should be visible through the API have been explicitly defined.
* Cast types for the attributes have been explicitly defined on the model.
* Filterable operators on models have been explicitly defined.
* Added UUID import statement to seeders.
* Updated unit tests to account for the changes to the codebase.