### PR TITLE
Incorporate relation loading for individual records

### DIFF
--- a/app/Helpers/QueryRequestFilter.php
+++ b/app/Helpers/QueryRequestFilter.php
@@ -100,6 +100,20 @@ class QueryRequestFilter
     }
 
     /**
+     * Fetch a specific record from the database, or fail trying to do so.
+     *
+     * @param string $id
+     * 
+     * @return \Illuminate\Database\Eloquent\Model
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function getResult(string $id): \Illuminate\Database\Eloquent\Model
+    {
+        return $this->query->where('id', $id)->firstOrFail();
+    }
+
+    /**
      * Fetches query results and sorts them according to the defined column and direction.
      *
      * @return \Illuminate\Database\Eloquent\Collection

--- a/app/Http/Controllers/ElementController.php
+++ b/app/Http/Controllers/ElementController.php
@@ -35,19 +35,19 @@ class ElementController extends Controller
      */
     public function index(Request $request): \Illuminate\Database\Eloquent\Collection
     {
-        return $this->elementRepository->applyRequestFilters($request->input());
+        return $this->elementRepository->getFilteredRecords($request->input());
     }
 
     /**
      * Display the specified resource.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \App\Models\Element $element
+     * @param string $elementId
      * 
      * @return \App\Models\Element
      */
-    public function show(Request $request, Element $element)
+    public function show(Request $request, string $elementId): \App\Models\Element
     {
-        return $element;
+        return $this->elementRepository->getRecordWithRelations($elementId, $request->input());
     }
 }

--- a/app/Http/Controllers/LocationController.php
+++ b/app/Http/Controllers/LocationController.php
@@ -35,19 +35,19 @@ class LocationController extends Controller
      */
     public function index(Request $request): \Illuminate\Database\Eloquent\Collection
     {
-        return $this->locationRepository->applyRequestFilters($request->input());
+        return $this->locationRepository->getFilteredRecords($request->input());
     }
 
     /**
      * Display the specified resource.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \App\Models\Location $location
+     * @param string $locationId
      * 
      * @return \App\Models\Location
      */
-    public function show(Request $request, Location $location)
+    public function show(Request $request, string $locationId): \App\Models\Location
     {
-        return $location;
+        return $this->locationRepository->getRecordWithRelations($locationId, $request->input());
     }
 }

--- a/app/Http/Controllers/SeedRankController.php
+++ b/app/Http/Controllers/SeedRankController.php
@@ -35,19 +35,19 @@ class SeedRankController extends Controller
      */
     public function index(Request $request): \Illuminate\Database\Eloquent\Collection
     {
-        return $this->seedRankRepository->applyRequestFilters($request->input());
+        return $this->seedRankRepository->getFilteredRecords($request->input());
     }
 
     /**
      * Display the specified resource.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \App\Models\SeedRank $seedRank
+     * @param string $seedRankId
      * 
-     * @return \App\Models\SeedRank $seedRank
+     * @return \App\Models\SeedRank
      */
-    public function show(Request $request, SeedRank $seedRank): \App\Models\SeedRank
+    public function show(Request $request, string $seedRankId): \App\Models\SeedRank
     {
-        return $seedRank;
+        return $this->seedRankRepository->getRecordWithRelations($seedRankId, $request->input());
     }
 }

--- a/app/Traits/Filterable.php
+++ b/app/Traits/Filterable.php
@@ -93,16 +93,33 @@ trait Filterable
     /**
      * Filters query results by the given parameters.
      *
-     * @param array $request
+     * @param array $filters
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function applyRequestFilters(array $filters): \Illuminate\Database\Eloquent\Collection
+    public function getFilteredRecords(array $filters): \Illuminate\Database\Eloquent\Collection
     {
         $query = new QueryRequestFilter($this->getModel());
 
-        return $query->loadRelations($filters)
-            ->applyFilters($filters)
-            ->getResults();
+        $query->loadRelations($filters)->applyFilters($filters);
+
+        return $query->getResults();
+    }
+
+    /**
+     * Fetches a record with the applicable relations requested by the filters.
+     *
+     * @param string $id
+     * @param array $filters
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     * 
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function getRecordWithRelations(string $id, array $filters): \Illuminate\Database\Eloquent\Model
+    {
+        $query = new QueryRequestFilter($this->getModel());
+
+        return $query->loadRelations($filters)->getResult($id);
     }
 }

--- a/tests/Feature/Routes/ElementRoutesTest.php
+++ b/tests/Feature/Routes/ElementRoutesTest.php
@@ -33,6 +33,14 @@ class ElementRoutesTest extends TestCase
     }
 
     /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/api/elements/invalid');
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
     public function multiple_colons_will_be_ignored_when_filtering_results()
     {
         factory(Element::class)->create([ 'name' => 'fire' ]);

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -33,6 +33,90 @@ class LocationRoutesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_load_relations_on_individual_records()
+    {
+        $balambRegion = factory(Location::class)->create([ 
+            'name' => 'Balamb Region', 
+            'description' => 'This is technically the parent',
+            'area' => 'Alcauld Plains', 
+        ]);
+        $balambGarden = factory(Location::class)->create([
+            'name' => 'Balamb Garden',
+            'region_id' => $balambRegion->id,
+            'description' => 'This is technically the child',
+            'area' => 'Alcauld Plains',
+        ]);
+
+        $response = $this->get("/api/locations/{$balambGarden->id}?with=region");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'region' => $balambRegion->toArray()
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_relation_properties_on_individual_records()
+    {
+        $balambRegion = factory(Location::class)->create([ 
+            'name' => 'Balamb Region', 
+            'description' => 'This is technically the parent',
+            'area' => 'Alcauld Plains', 
+        ]);
+        $balambGarden = factory(Location::class)->create([
+            'name' => 'Balamb Garden',
+            'region_id' => $balambRegion->id,
+            'description' => 'This is technically the child',
+            'area' => 'Alcauld Plains',
+        ]);
+
+        $response = $this->get("/api/locations/{$balambGarden->id}?with=region.name");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'region' => [
+                'id' => $balambRegion->id,
+                'name' => $balambRegion->name,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_multiple_relation_properties_on_individual_records()
+    {
+        $balambRegion = factory(Location::class)->create([ 
+            'name' => 'Balamb Region', 
+            'description' => 'This is technically the parent',
+            'area' => 'Alcauld Plains', 
+        ]);
+        $balambGarden = factory(Location::class)->create([
+            'name' => 'Balamb Garden',
+            'region_id' => $balambRegion->id,
+            'description' => 'This is technically the child',
+            'area' => 'Alcauld Plains',
+        ]);
+
+        $response = $this->get("/api/locations/{$balambGarden->id}?with=region.name,region.area");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'region' => [
+                'id' => $balambRegion->id,
+                'name' => $balambRegion->name,
+                'area' => $balambRegion->area,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/api/locations/invalid');
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
     public function multiple_colons_will_be_ignored_when_filtering_results()
     {
         factory(Location::class)->create([ 'name' => 'Balamb Region' ]);

--- a/tests/Feature/Routes/SeedRankRoutesTest.php
+++ b/tests/Feature/Routes/SeedRankRoutesTest.php
@@ -33,6 +33,14 @@ class SeedRankRoutesTest extends TestCase
     }
 
     /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/api/seed-ranks/invalid');
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
     public function multiple_colons_will_be_ignored_when_filtering_results()
     {
         factory(SeedRank::class)->create([ 'rank' => 1 ]);

--- a/tests/Unit/Controllers/ElementControllerTest.php
+++ b/tests/Unit/Controllers/ElementControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Controllers;
 use App\Http\Controllers\ElementController;
 use App\Models\Element;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Tests\TestCase;
@@ -34,13 +35,25 @@ class ElementControllerTest extends TestCase
 
         $elementController = new ElementController(new Element());
 
-        $response = $elementController->show(new Request(), $element);
+        $response = $elementController->show(new Request(), $element->id);
 
         // The controller should return the instance of a Element that was found via 
         // route model binding. Since we are mocking this result by injecting the
         // Element into the method, we should get the same Element back.
         $this->assertInstanceOf(Element::class, $response);
-        $this->assertEquals($element, $response);
+        $this->assertEquals($element->toArray(), $response->toArray());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $element = factory(Element::class)->create();
+
+        $elementController = new ElementController(new Element());
+
+        $response = $elementController->show(new Request(), 'invalid');
     }
 
     /** @test */

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Controllers;
 use App\Http\Controllers\LocationController;
 use App\Models\Location;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Tests\TestCase;
@@ -34,13 +35,125 @@ class LocationControllerTest extends TestCase
 
         $locationController = new LocationController(new Location());
 
-        $response = $locationController->show(new Request(), $location);
+        $response = $locationController->show(new Request(), $location->id);
 
         // The controller should return the instance of a Location that was found via 
         // route model binding. Since we are mocking this result by injecting the
         // Location into the method, we should get the same Location back.
         $this->assertInstanceOf(Location::class, $response);
-        $this->assertEquals($location, $response);
+        $this->assertEquals($location->toArray(), $response->toArray());
+    }
+
+    /** @test */
+    public function it_can_load_relations_on_individual_records()
+    {
+        $balambRegion = factory(Location::class)->create([ 
+            'name' => 'Balamb Region', 
+            'description' => 'This is technically the parent',
+            'area' => 'Alcauld Plains', 
+        ]);
+        $balambGarden = factory(Location::class)->create([
+            'name' => 'Balamb Garden',
+            'region_id' => $balambRegion->id,
+            'description' => 'This is technically the child',
+            'area' => 'Alcauld Plains',
+        ]);
+
+        $locationController = new LocationController(new Location());
+
+        $response = $locationController->show(new Request([
+            'with' => 'region',
+        ]), $balambGarden->id);
+
+        $this->assertTrue(array_key_exists(
+            'region', 
+            $response->toArray()
+        ));
+        $this->assertEquals(
+            $balambRegion->toArray(), 
+            $response->region->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_can_load_relation_properties_on_individual_records()
+    {
+        $balambRegion = factory(Location::class)->create([ 
+            'name' => 'Balamb Region', 
+            'description' => 'This is technically the parent',
+            'area' => 'Alcauld Plains', 
+        ]);
+        $balambGarden = factory(Location::class)->create([
+            'name' => 'Balamb Garden',
+            'region_id' => $balambRegion->id,
+            'description' => 'This is technically the child',
+            'area' => 'Alcauld Plains',
+        ]);
+
+        $locationController = new LocationController(new Location());
+
+        $response = $locationController->show(new Request([
+            'with' => 'region.name',
+        ]), $balambGarden->id);
+
+        $this->assertTrue(array_key_exists(
+            'region', 
+            $response->toArray()
+        ));
+        $this->assertEquals(
+            [
+                'id' => $balambRegion->id,
+                'name' => $balambRegion->name,
+            ], 
+            $response->region->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_can_load_multiple_relation_properties_on_individual_records()
+    {
+        $balambRegion = factory(Location::class)->create([ 
+            'name' => 'Balamb Region', 
+            'description' => 'This is technically the parent',
+            'area' => 'Alcauld Plains', 
+        ]);
+        $balambGarden = factory(Location::class)->create([
+            'name' => 'Balamb Garden',
+            'region_id' => $balambRegion->id,
+            'description' => 'This is technically the child',
+            'area' => 'Alcauld Plains',
+        ]);
+
+        $locationController = new LocationController(new Location());
+
+        $response = $locationController->show(new Request([
+            'with' => 'region.name,region.area',
+        ]), $balambGarden->id);
+
+        $this->assertTrue(array_key_exists(
+            'region', 
+            $response->toArray()
+        ));
+        $this->assertEquals(
+            [
+                'id' => $balambRegion->id,
+                'name' => $balambRegion->name,
+                'area' => $balambRegion->area,
+            ], 
+            $response->region->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $location = factory(Location::class)->create();
+
+        $locationController = new LocationController(new Location());
+
+        $response = $locationController->show(new Request(), 'invalid');
     }
 
     /** @test */

--- a/tests/Unit/Controllers/SeedRankControllerTest.php
+++ b/tests/Unit/Controllers/SeedRankControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Controllers;
 use App\Http\Controllers\SeedRankController;
 use App\Models\SeedRank;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Tests\TestCase;
@@ -34,13 +35,25 @@ class SeedRankControllerTest extends TestCase
 
         $seedRankController = new SeedRankController(new SeedRank);
 
-        $response = $seedRankController->show(new Request(), $seedRank);
+        $response = $seedRankController->show(new Request(), $seedRank->id);
 
         // The controller should return the instance of a Seed Rank that was found via 
         // route model binding. Since we are mocking this result by injecting the
         // Seed Rank into the method, we should get the same Seed Rank back.
         $this->assertInstanceOf(SeedRank::class, $response);
-        $this->assertEquals($seedRank, $response);
+        $this->assertEquals($seedRank->toArray(), $response->toArray());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $seedRank = factory(SeedRank::class)->create();
+
+        $seedRankController = new SeedRankController(new SeedRank());
+
+        $response = $seedRankController->show(new Request(), 'invalid');
     }
 
     /** @test */


### PR DESCRIPTION
Previously, filters and relation loading was applied only to index routes. This PR adds support for relation loading when accessing an individual record. Relations for individual records may be loaded using the same schema as with indexed routes.

* `/api/{resource}/{resourceId}?with={relation}{.relationColumnName?}{,relation?}{.relationColumnName?}`

Examples:

* `/api/locations/d2751c39-45ce-49ec-85d2-aa32946396b1?with=region`
* `/api/locations/d2751c39-45ce-49ec-85d2-aa32946396b1?with=region.name`
* `/api/locations/d2751c39-45ce-49ec-85d2-aa32946396b1?with=region.name,region.area`

In order to support this change, the `Filterable` trait, and the `QueryRequestFilter` class needed to be refactored. As part of this refactor the `applyRequestFilters` on the `Filterable` trait method name has been changed to `applyRequestFilters`. This class is now designated to fetch a collection of records, while the `getRecordWithRelations` is intended to fetch a single record with only the relations loaded.