### PR TITLE
Add Stat resources

### DIFF
--- a/app/Models/Stat.php
+++ b/app/Models/Stat.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Model;
+
+class Stat extends Model
+{
+    use Uuids;
+
+    /** 
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'stats';
+
+    /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [];
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'name',
+        'abbreviation',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array $hidden
+     */
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array $casts
+     */
+    protected $casts = [
+        'id'            => 'string',
+        'name'          => 'string',
+        'abbreviation'  => 'string',
+    ];
+}

--- a/database/factories/StatFactory.php
+++ b/database/factories/StatFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\Stat;
+use Faker\Generator as Faker;
+
+$factory->define(Stat::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+        'abbreviation' => $faker->word,
+    ];
+});

--- a/database/migrations/2019_11_09_060543_create_stats_table.php
+++ b/database/migrations/2019_11_09_060543_create_stats_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStatsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('stats', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('abbreviation');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('stats');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
         $this->call(SeedRanksTableSeeder::class);
         $this->call(ElementsTableSeeder::class);
         $this->call(LocationsTableSeeder::class);
+        $this->call(StatsTableSeeder::class);
     }
 }

--- a/database/seeds/StatsTableSeeder.php
+++ b/database/seeds/StatsTableSeeder.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\Stat;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class StatsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $stats = [
+            [
+                'name' => 'hit points',
+                'abbreviation' => 'hp',
+            ],
+            [
+                'name' => 'strength',
+                'abbreviation' => 'str',
+            ],
+            [
+                'name' => 'vitality',
+                'abbreviation' => 'vit',
+            ],
+            [
+                'name' => 'magic',
+                'abbreviation' => 'mag',
+            ],
+            [
+                'name' => 'spirit',
+                'abbreviation' => 'spr',
+            ],
+            [
+                'name' => 'speed',
+                'abbreviation' => 'spd',
+            ],
+            [
+                'name' => 'luck',
+                'abbreviation' => 'luck',
+            ],
+            [
+                'name' => 'evade',
+                'abbreviation' => 'eva',
+            ],
+            [
+                'name' => 'hit',
+                'abbreviation' => 'hit',
+            ],
+        ];
+
+        // Assign a UUID and timestamp to each record.
+        // Do this in bulk to maintain readability.
+        foreach ($stats as $key => $value) {
+            $stats[$key]['id'] = Uuid::generate(4);
+            $stats[$key]['created_at'] = Carbon::now();
+            $stats[$key]['updated_at'] = Carbon::now();
+        }
+
+        $stat = new Stat();
+
+        $stat->insert($stats);
+    }
+}

--- a/tests/Unit/Models/StatTest.php
+++ b/tests/Unit/Models/StatTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Stat;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatTest extends TestCase
+{
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $stat = new Stat();
+
+        $this->assertEquals('stats', $stat->getTable());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $stat = new Stat();
+
+        $this->assertEquals('string', $stat->getKeyType());
+    }
+
+    /** @test */
+    public function it_does_not_allow_properties_to_be_assigned_in_mass()
+    {
+        $stat = new Stat();
+
+        $this->assertEquals([], $stat->getFillable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $stat = new Stat();
+
+        $visibleFields = [
+            'id',
+            'name',
+            'abbreviation',
+        ];
+
+        $this->assertEquals($visibleFields, $stat->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    {
+        $stat = new Stat();
+
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',    
+        ];
+
+        $this->assertEquals($hiddenFields, $stat->getHidden());
+    }
+
+    /** @test */
+    public function it_casts_the_name_column_to_a_string()
+    {
+        $stat = new Stat();
+        $casts = $stat->getCasts();
+
+        $this->assertArrayHasKey('name', $casts);
+        $this->assertEquals('string', $casts['name']);
+    }
+
+    /** @test */
+    public function it_casts_the_abbreviation_column_to_a_string()
+    {
+        $stat = new Stat();
+        $casts = $stat->getCasts();
+
+        $this->assertArrayHasKey('abbreviation', $casts);
+        $this->assertEquals('string', $casts['abbreviation']);
+    }
+}


### PR DESCRIPTION
This PR adds the `Stat` resources to the API. The `Stat` resource is not intended to be a searchable field indexed by the API, but rather a table that ties `Stats` to various other resources such as characters or monsters. With this being the case, there are no routes or controllers, nor is it listed as a filterable class.