### PR TITLE
Added the resources necessary for the Status Effects resource

### DIFF
--- a/app/Http/Controllers/StatusEffectController.php
+++ b/app/Http/Controllers/StatusEffectController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\StatusEffect;
+use Illuminate\Http\Request;
+
+class StatusEffectController extends Controller
+{
+    /**
+     * Instance of the StatusEffect Model.
+     *
+     * @var \App\Models\StatusEffect $statusEffectRepository
+     */
+    protected $statusEffectRepository;
+
+    /**
+     * Sets the StatusEffectRepository instance to be used throughout the controller.
+     *
+     * @param \App\Models\StatusEffect $statusEffect
+     * 
+     * @return void
+     */
+    public function __construct(StatusEffect $statusEffect)
+    {
+        $this->statusEffectRepository = $statusEffect;
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param \Illuminate\Http\Request $request
+     * 
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function index(Request $request): \Illuminate\Database\Eloquent\Collection
+    {
+        return $this->statusEffectRepository->getFilteredRecords($request->input());
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param string $statusEffectId
+     * 
+     * @return \App\Models\StatusEffect
+     */
+    public function show(Request $request, string $statusEffectId): \App\Models\StatusEffect
+    {
+        return $this->statusEffectRepository->getRecordWithRelations($statusEffectId, $request->input());
+    }
+}

--- a/app/Models/StatusEffect.php
+++ b/app/Models/StatusEffect.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Filterable;
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Model;
+
+class StatusEffect extends Model
+{
+    use Uuids;
+    use Filterable;
+
+    /** 
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'status_effects';
+
+    /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [];
+
+    /**
+     * The default field used to order query results by.
+     *
+     * @var array
+     */
+    protected $orderByField = 'name';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var array
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'name',
+        'type',
+        'description',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array $hidden
+     */
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array $casts
+     */
+    protected $casts = [
+        'id'            => 'string',
+        'name'          => 'string',
+        'type'          => 'string',
+        'description'   => 'string',
+    ];
+
+    /**
+     * The fields that are explicitly enabled for filtering.
+     *
+     * @var array $filterableFields
+     */
+    protected $filterableFields = [
+        'name',
+        'type',
+    ];
+
+    /**
+     * The operators that are explicitly enabled for filtering.
+     *
+     * @return array
+     */
+    protected $filterableOperators = [
+        'like' => 'like',
+        'not' => '<>',
+    ];
+}

--- a/database/factories/StatusEffectFactory.php
+++ b/database/factories/StatusEffectFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\StatusEffect;
+use Faker\Generator as Faker;
+
+$factory->define(StatusEffect::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+        'type' => $faker->word,
+        'description' => $faker->paragraph,
+    ];
+});

--- a/database/migrations/2019_11_09_232423_create_status_effects_table.php
+++ b/database/migrations/2019_11_09_232423_create_status_effects_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStatusEffectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('status_effects', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('type');
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('status_effects');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -16,5 +16,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ElementsTableSeeder::class);
         $this->call(LocationsTableSeeder::class);
         $this->call(StatsTableSeeder::class);
+        $this->call(StatusEffectsTableSeeder::class);
     }
 }

--- a/database/seeds/StatusEffectsTableSeeder.php
+++ b/database/seeds/StatusEffectsTableSeeder.php
@@ -1,0 +1,172 @@
+<?php
+
+use App\Models\StatusEffect;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class StatusEffectsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $statusEffects = [
+            [
+                'name' => 'death',
+                'type' => 'harmful',
+                'description' => "The Death status reduces the target's HP to 0. Monsters afflicted with death are removed from combat. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'poison',
+                'type' => 'harmful',
+                'description' => "The Poison status deals damage to the target after each action they take. The damage is around 1/20th of the target's maximum HP each tick. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'petrify',
+                'type' => 'harmful',
+                'description' => "The Petrify status will render the target unable to perform any actions. Enemies will be considered as removed from combat. If all targets are petrified (either enemies or players), the battle will end. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'darkness',
+                'type' => 'harmful',
+                'description' => "The Darkness status will reduce the targets hit by 75%. Characters that have 255% hit will be unaffected by this status. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'silence',
+                'type' => 'harmful',
+                'description' => "The Silence status will render targets unable to use the magic, GF, and draw commands. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'berserk',
+                'type' => 'harmful',
+                'description' => "The Berserk status will force the target to perform basic attacks on a random target during each turn. Attacks are boosted by 50% of their normal value. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'zombie',
+                'type' => 'harmful',
+                'description' => "The Zombie status causes the target to act as if undead. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'sleep',
+                'type' => 'harmful',
+                'description' => "The Sleep status will render targets unable to perform an actions. Receiving physical damage will remove the effect. This effect will wear off automatically over time.",
+            ],
+            [
+                'name' => 'haste',
+                'type' => 'beneficial',
+                'description' => "The Haste status increases the rate at which the ATB bar fills, but also decreases how long beneficial Status Effects last. This effect will wear off automatically over time.",
+            ],
+            [
+                'name' => 'slow',
+                'type' => 'harmful',
+                'description' => "The Slow status decreases the rate at which the ATB bar fills, but also increases how long beneficial Status Effects last. This effect will wear off automatically over time.",
+            ],
+            [
+                'name' => 'stop',
+                'type' => 'harmful',
+                'description' => "The Stop status will render targets unable to execute any commands. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'regen',
+                'type' => 'beneficial',
+                'description' => "The Regen status heals the target for a total of 80% of their maximum HP. This is done in 5% increments over the course of 16 ticks. This effect will wear off automatically over time.",
+            ],
+            [
+                'name' => 'protect',
+                'type' => 'beneficial',
+                'description' => "The Protect status halves physical damage dealt to the target. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'shell',
+                'type' => 'beneficial',
+                'description' => "The Shell status halves magical damage dealt to the target. This reduction also affects curing spells. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'reflect',
+                'type' => 'beneficial',
+                'description' => "The Reflect status redirects most single-target magic toward a random target on the opposing team. Spells can only be reflected once. Not all magic can be reflected. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'aura',
+                'type' => 'beneficial',
+                'description' => "The Aura status significantly increases the chances of a character being able to use a limit break. This status also enhances the power of limit breaks. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'curse',
+                'type' => 'harmful',
+                'description' => "The Curse status restricts a character from using limit breaks. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'doom',
+                'type' => 'harmful',
+                'description' => "The Doom status places a countdown timer on the target. When this timer expires, the target will be KO'd. If the battle ends before the countdown has finished, the status will be removed.",
+            ],
+            [
+                'name' => 'invincible',
+                'type' => 'beneficial',
+                'description' => "The Invincible status prevents targets from taking any form of damage. This status also prevents both beneficial, and harmful statuses from being applied to the target. Becoming Invincible removes any current negative status effects. Targets that are under the effect of Invincible can be healed by spells and items. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'petrifying',
+                'type' => 'harmful',
+                'description' => "The Petrifying status places a countdown timer on the target. When this timer expired, the target will be afflicted with the Petrify status. If battle ends before the countdown has finished, the status will be removed.",
+            ],
+            [
+                'name' => 'float',
+                'type' => 'beneficial',
+                'description' => "The Floating status makes targets immune to earth based damage. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'confuse',
+                'type' => 'harmful',
+                'description' => "The Confuse status makes targets use attacks, magic, or items on any ally (including themselves) or enemy at random. This status will wear off at the end of battle, or if physical damage is taken. This effect wears off automatically over time.",
+            ],
+            [
+                'name' => 'double',
+                'type' => 'beneficial',
+                'description' => "The Double status allows a target to cast magic twice in one turn. Casting two spells in one turn will consume two stocks of the spell that is cast. If the Expendx2-1 ability is in use, it will only consume one stocked spell. This effect will last until the end of battle.",
+            ],
+            [
+                'name' => 'triple',
+                'type' => 'beneficial',
+                'description' => "The Triple status allows a target to cast magic three times in one turn. Casting three spells in one turn will consume three stocks of the spell that is cast. If the Expendx3-1 ability is in use, it will only consume one stocked spell. This effect will last until the end of battle.",
+            ],
+            [
+                'name' => 'defend',
+                'type' => 'beneficial',
+                'description' => "The Defend status will prevent all physical damage and will halve magic damage received until another command is chosen. Physical attacks that can inflict status ailments will never have an effect on a target that under the Defend status.",
+            ],
+            [
+                'name' => 'vit 0',
+                'type' => 'harmful',
+                'description' => "The Vit 0 status reduces both vitality and spirit to 0, making the target more vulnerable to both physical and magic attacks. This effect lasts until battle ends.",
+            ],
+            [
+                'name' => 'angel wing',
+                'type' => 'beneficial',
+                'description' => "The Angel Wing status is granted by Rinoa's Angel Wing limit break. This status will cause Rinoa to cast random spells on random targets, without consuming stocked spells. Spells deal 5 times the normal damage, and the effect lasts until the end of combat.",
+            ],
+            [
+                'name' => 'drain',
+                'type' => 'harmful',
+                'description' => "The Drain status is used exclusively for calculating the amount of hit points gained from using a Drain effect. If the target has Drain resistance, they will take normal damage, however the user will regain hit points proportional to the target's Drain resistance.",
+            ],
+        ];
+
+        // Assign a UUID and timestamp to each record.
+        // Do this in bulk to maintain readability.
+        foreach ($statusEffects as $key => $value) {
+            $statusEffects[$key]['id'] = Uuid::generate(4);
+            $statusEffects[$key]['created_at'] = Carbon::now();
+            $statusEffects[$key]['updated_at'] = Carbon::now();
+        }
+
+        $statusEffect = new StatusEffect();
+
+        $statusEffect->insert($statusEffects);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,3 +7,4 @@ Route::get('/status')->uses('StatusController@healthCheck');
 Route::resource('seed-ranks', 'SeedRankController')->only(['index', 'show']);
 Route::resource('elements', 'ElementController')->only(['index', 'show']);
 Route::resource('locations', 'LocationController')->only(['index', 'show']);
+Route::resource('status-effects', 'StatusEffectController')->only(['index', 'show']);

--- a/tests/Feature/Routes/StatusEffectRoutesTest.php
+++ b/tests/Feature/Routes/StatusEffectRoutesTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature\Routes;
+
+use App\Models\StatusEffect;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatusEffectRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_returns_a_list_of_status_effects()
+    {
+        $statusEffects = factory(StatusEffect::class, 10)->create();
+
+        $response = $this->get('/api/status-effects');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(10);
+    }
+
+    /** @test */
+    public function it_returns_an_individual_statusEffect()
+    {
+        $statusEffect = factory(StatusEffect::class)->create();
+
+        $response = $this->get("/api/status-effects/{$statusEffect->id}");
+
+        $response->assertStatus(200);
+        $response->assertJson($statusEffect->toArray());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/api/status-effects/invalid');
+
+        $response->assertStatus(404);
+    }
+
+    /** @test */
+    public function multiple_colons_will_be_ignored_when_filtering_results()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?name=like:le:0');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([ 'name' => 'Double' ]);
+        $response->assertJsonFragment([ 'name' => 'Triple' ]);
+    }
+
+    /** @test */
+    public function the_name_column_can_be_filtered_by_the_equals_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?name=Death');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment([ 'name' => 'Death' ]);
+    }
+
+    /** @test */
+    public function the_name_column_can_be_filtered_by_the_like_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?name=like:le');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([ 'name' => 'Double' ]);
+        $response->assertJsonFragment([ 'name' => 'Triple' ]);
+    }
+
+    /** @test */
+    public function the_name_column_can_be_filtered_by_the_not_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?name=not:Double');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([ 'name' => 'Death' ]);
+        $response->assertJsonFragment([ 'name' => 'Triple' ]);
+    }
+
+    /** @test */
+    public function the_type_column_can_be_filtered_by_the_equals_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?type=harmful');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment([ 'name' => 'Death' ]);
+        $response->assertJsonFragment([ 'type' => 'harmful' ]);
+    }
+
+    /** @test */
+    public function the_type_column_can_be_filtered_by_the_like_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?type=like:cial');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([ 'name' => 'Double' ]);
+        $response->assertJsonFragment([ 'name' => 'Triple' ]);
+    }
+
+    /** @test */
+    public function the_type_column_can_be_filtered_by_the_not_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?type=not:beneficial');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment([ 'name' => 'Death' ]);
+        $response->assertJsonFragment([ 'type' => 'harmful' ]);
+    }
+
+    /** @test */
+    public function the_name_and_type_columns_can_both_be_filtered_together()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $response = $this->get('/api/status-effects?name=like:Dou&type=like:ficial');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment([
+            'name' => 'Double',
+            'type' => 'beneficial',
+        ]);
+    }
+}

--- a/tests/Unit/Controllers/StatusEffectControllerTest.php
+++ b/tests/Unit/Controllers/StatusEffectControllerTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Unit\Controllers;
+
+
+use App\Http\Controllers\StatusEffectController;
+use App\Models\StatusEffect;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class StatusEffectControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_can_return_a_list_of_status_effects()
+    {
+        $statusEffects = factory(StatusEffect::class, 10)->create();
+
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+
+        $response = $statusEffectController->index(new Request());
+
+        // Controller should return a collection of StatusEffects.
+        $this->assertInstanceOf(Collection::class, $response);
+        $this->assertCount(10, $response);
+    }
+
+    /** @test */
+    public function it_returns_an_individual_status_effect()
+    {
+        $statusEffect = factory(StatusEffect::class)->create();
+
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+
+        $response = $statusEffectController->show(new Request(), $statusEffect->id);
+
+        // The controller should return the instance of a StatusEffect that was found via 
+        // route model binding. Since we are mocking this result by injecting the
+        // StatusEffect into the method, we should get the same StatusEffect back.
+        $this->assertInstanceOf(StatusEffect::class, $response);
+        $this->assertEquals($statusEffect->toArray(), $response->toArray());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $statusEffect = factory(StatusEffect::class)->create();
+
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+
+        $response = $statusEffectController->show(new Request(), 'invalid');
+    }
+
+    /** @test */
+    public function multiple_colons_will_be_ignored_when_filtering_results()
+    {
+        // Set the filterable operators on the StatusEffect class.
+        $statusEffect = new StatusEffect();
+        $statusEffect->filterableOperators = [ 'like' => 'like' ];
+
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'name' => 'like:le:w' ]);
+        $statusEffectController = new StatusEffectController($statusEffect);
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(2, $response);
+        $this->assertTrue($response->contains('name', 'Double'));
+        $this->assertTrue($response->contains('name', 'Triple'));
+    }
+
+    /** @test */
+    public function the_filters_are_case_insensitive()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'name' => 'death' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(1, $response);
+        $this->assertTrue($response->contains('name', 'Death'));
+    }
+
+    /** @test */
+    public function the_name_column_can_be_filtered_by_the_equals_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'name' => 'Triple' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(1, $response);
+        $this->assertTrue($response->contains('name', 'Triple'));
+    }
+
+    /** @test */
+    public function the_name_column_can_be_filtered_by_the_like_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'name' => 'like:le' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(2, $response);
+        $this->assertTrue($response->contains('name', 'Double'));
+        $this->assertTrue($response->contains('name', 'Triple'));
+    }
+
+    /** @test */
+    public function the_name_column_can_be_filtered_by_the_not_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'name' => 'not:Triple' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(2, $response);
+        $this->assertTrue($response->contains('name', 'Death'));
+        $this->assertTrue($response->contains('name', 'Double'));
+    }
+
+    /** @test */
+    public function the_type_column_can_be_filtered_by_the_equals_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'type' => 'harmful' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(1, $response);
+        $this->assertTrue($response->contains('type', 'harmful'));
+    }
+
+    /** @test */
+    public function the_type_column_can_be_filtered_by_the_like_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'type' => 'like:cial' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(2, $response);
+        $this->assertTrue($response->contains('type', 'beneficial'));
+        $this->assertTrue($response->contains('name', 'Double'));
+        $this->assertTrue($response->contains('name', 'Triple'));
+    }
+
+    /** @test */
+    public function the_type_column_can_be_filtered_by_the_not_operator()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([ 'type' => 'not:beneficial' ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(1, $response);
+        $this->assertTrue($response->contains('name', 'Death'));
+        $this->assertTrue($response->contains('type', 'harmful'));
+    }
+
+    /** @test */
+    public function the_name_and_type_columns_can_both_be_filtered_together()
+    {
+        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+
+        $request = new Request([
+            'name' => 'like:Dou',
+            'type' => 'like:ficial',
+        ]);
+        $statusEffectController = new StatusEffectController(new StatusEffect());
+        $response = $statusEffectController->index($request);
+
+        $this->assertCount(1, $response);
+        $this->assertTrue($response->contains('name', 'Double'));
+        $this->assertTrue($response->contains('type', 'beneficial'));
+    }
+}

--- a/tests/Unit/Models/StatusEffectTest.php
+++ b/tests/Unit/Models/StatusEffectTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\StatusEffect;
+use App\Traits\Filterable;
+use Tests\TestCase;
+
+class StatusEffectTest extends TestCase
+{
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('status_effects', $statusEffect->getTable());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('string', $statusEffect->getKeyType());
+    }
+
+    /** @test */
+    public function it_does_not_allow_properties_to_be_assigned_in_mass()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals([], $statusEffect->getFillable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $statusEffect = new StatusEffect();
+
+        $visibleFields = [
+            'id',
+            'name',
+            'type',
+            'description',
+        ];
+
+        $this->assertEquals($visibleFields, $statusEffect->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    {
+        $statusEffect = new StatusEffect();
+
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',    
+        ];
+
+        $this->assertEquals($hiddenFields, $statusEffect->getHidden());
+    }
+
+    /** @test */
+    public function it_casts_the_name_column_to_a_string()
+    {
+        $statusEffect = new StatusEffect();
+        $casts = $statusEffect->getCasts();
+
+        $this->assertArrayHasKey('name', $casts);
+        $this->assertEquals('string', $casts['name']);
+    }
+
+    /** @test */
+    public function it_casts_the_type_column_to_a_string()
+    {
+        $statusEffect = new StatusEffect();
+        $casts = $statusEffect->getCasts();
+
+        $this->assertArrayHasKey('type', $casts);
+        $this->assertEquals('string', $casts['type']);
+    }
+
+    /** @test */
+    public function it_casts_the_description_column_to_a_string()
+    {
+        $statusEffect = new StatusEffect();
+        $casts = $statusEffect->getCasts();
+
+        $this->assertArrayHasKey('description', $casts);
+        $this->assertEquals('string', $casts['description']);
+    }
+
+    /** @test */
+    public function it_is_able_to_filter_records()
+    {
+        $this->assertTrue(in_array(
+            Filterable::class, 
+            class_uses(StatusEffect::class)
+        ));
+    }
+
+    /** @test */
+    public function it_allows_specific_fields_to_be_filtered()
+    {
+        $statusEffect = new StatusEffect();
+        $shouldBeFilterable = [
+            'name',
+            'type',
+        ];
+
+        $this->assertEquals($shouldBeFilterable, $statusEffect->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_orders_results_by_name()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('name', $statusEffect->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('asc', $statusEffect->getOrderByDirection());
+    }
+}


### PR DESCRIPTION
This PR adds the necessary scaffolding for including Status Effects resource. The Status Effects resource has an API endpoint that will eventually tie to other models. For now, it is simple an index of the resource itself. The additional resources will be added in an individual PR, after which everything will be tied together.