### PR TITLE
Upgrade Laravel to version 8

### DIFF
--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -4,14 +4,16 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Element extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -4,12 +4,14 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Item extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
     /**
      * The table associated with the model.

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -4,14 +4,16 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Location extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Webpatser\Uuid\Uuid;
 
@@ -11,8 +12,9 @@ class SeedRank extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -11,8 +12,9 @@ class SeedTest extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string
@@ -121,7 +123,7 @@ class SeedTest extends Model
     /**
      * The questions that relate to the test.
      *
-     * @return 
+     * @return
      */
     public function questions()
     {

--- a/app/Models/Stat.php
+++ b/app/Models/Stat.php
@@ -3,13 +3,15 @@
 namespace App\Models;
 
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Stat extends Model
 {
     use Uuids;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string

--- a/app/Models/StatusEffect.php
+++ b/app/Models/StatusEffect.php
@@ -4,14 +4,16 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class StatusEffect extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Traits\Filterable;
 use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -11,8 +12,9 @@ class TestQuestion extends Model
 {
     use Uuids;
     use Filterable;
+    use HasFactory;
 
-    /** 
+    /**
      * The table associated with the model.
      *
      * @var string $table
@@ -126,9 +128,9 @@ class TestQuestion extends Model
         'not' => '<>',
     ];
 
-    /** 
+    /**
      * The SeedTest that the record belongs to.
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function test()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,12 +3,14 @@
 namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
     use Notifiable;
+    use HasFactory;
 
     /**
      * The attributes that are mass assignable.

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,17 @@
     "require": {
         "php": "^7.2",
         "fideloper/proxy": "^4.0",
-        "laravel/framework": "^7.0",
+        "guzzlehttp/guzzle": "^7.0.1",
+        "laravel/framework": "^8.0",
         "laravel/tinker": "^2.0",
         "webpatser/laravel-uuid": "^3.0"
     },
     "require-dev": {
-        "facade/ignition": "^2.0",
+        "facade/ignition": "^2.3.6",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
-        "nunomaduro/collision": "^4.1",
-        "phpunit/phpunit": "^8.5"
+        "nunomaduro/collision": "^5.0",
+        "phpunit/phpunit": "^9.0"
     },
     "config": {
         "optimize-autoloader": true,
@@ -33,12 +34,10 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
-        },
-        "classmap": [
-            "database/seeds",
-            "database/factories"
-        ]
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bb074006d0b5cc5086998c2f03ffc1e",
+    "content-hash": "2fd894fc53239692a5d0ae9af7c9de35",
     "packages": [
         {
             "name": "brick/math",
@@ -226,30 +226,29 @@
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27"
+                "reference": "fa4e95ff5a7f1d62c3fbc05c32729b7f3ca14b52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/72b6fbf76adb3cf5bc0db68559b33d41219aba27",
-                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/fa4e95ff5a7f1d62c3fbc05c32729b7f3ca14b52",
+                "reference": "fa4e95ff5a7f1d62c3fbc05c32729b7f3ca14b52",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "mtdowling/cron-expression": "^1.0"
             },
             "require-dev": {
+                "phpstan/phpstan": "^0.11",
                 "phpunit/phpunit": "^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Cron\\": "src/Cron/"
@@ -261,11 +260,6 @@
             ],
             "authors": [
                 {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
                     "name": "Chris Tankersley",
                     "email": "chris@ctankersley.com",
                     "homepage": "https://github.com/dragonmantank"
@@ -276,7 +270,7 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2019-03-31T00:38:28+00:00"
+            "time": "2020-08-21T02:30:13+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -391,22 +385,276 @@
             "time": "2020-06-23T01:36:47+00:00"
         },
         {
-            "name": "laravel/framework",
-            "version": "v7.28.3",
+            "name": "graham-campbell/result-type",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laravel/framework.git",
-                "reference": "b0942c391975972b1a54b2dc983e33a239f169a9"
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/b0942c391975972b1a54b2dc983e33a239f169a9",
-                "reference": "b0942c391975972b1a54b2dc983e33a239f169a9",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0",
+                "phpoption/phpoption": "^1.7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "time": "2020-04-13T13:17:36+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7edeaa528fbb57123028bd5a76b9ce9540194e26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7edeaa528fbb57123028bd5a76b9ce9540194e26",
+                "reference": "7edeaa528fbb57123028bd5a76b9ce9540194e26",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": "^7.2.5",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "dev-phpunit8",
+                "phpunit/phpunit": "^8.5.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "time": "2020-09-22T09:10:04+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "laravel/framework",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/framework.git",
+                "reference": "a71952a6dba55de0bb11b5fbbd84874eda2a755c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/a71952a6dba55de0bb11b5fbbd84874eda2a755c",
+                "reference": "a71952a6dba55de0bb11b5fbbd84874eda2a755c",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "^1.4|^2.0",
-                "dragonmantank/cron-expression": "^2.0",
+                "dragonmantank/cron-expression": "^3.0",
                 "egulias/email-validator": "^2.1.10",
                 "ext-json": "*",
                 "ext-mbstring": "*",
@@ -415,24 +663,23 @@
                 "league/flysystem": "^1.0.34",
                 "monolog/monolog": "^2.0",
                 "nesbot/carbon": "^2.17",
-                "opis/closure": "^3.1",
-                "php": "^7.2.5",
+                "opis/closure": "^3.5.3",
+                "php": "^7.3",
                 "psr/container": "^1.0",
                 "psr/simple-cache": "^1.0",
-                "ramsey/uuid": "^3.7|^4.0",
+                "ramsey/uuid": "^4.0",
                 "swiftmailer/swiftmailer": "^6.0",
-                "symfony/console": "^5.0",
-                "symfony/error-handler": "^5.0",
-                "symfony/finder": "^5.0",
-                "symfony/http-foundation": "^5.0",
-                "symfony/http-kernel": "^5.0",
-                "symfony/mime": "^5.0",
-                "symfony/polyfill-php73": "^1.17",
-                "symfony/process": "^5.0",
-                "symfony/routing": "^5.0",
-                "symfony/var-dumper": "^5.0",
+                "symfony/console": "^5.1",
+                "symfony/error-handler": "^5.1",
+                "symfony/finder": "^5.1",
+                "symfony/http-foundation": "^5.1",
+                "symfony/http-kernel": "^5.1",
+                "symfony/mime": "^5.1",
+                "symfony/process": "^5.1",
+                "symfony/routing": "^5.1",
+                "symfony/var-dumper": "^5.1",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-                "vlucas/phpdotenv": "^4.0",
+                "vlucas/phpdotenv": "^5.2",
                 "voku/portable-ascii": "^1.4.8"
             },
             "conflict": {
@@ -446,6 +693,7 @@
                 "illuminate/broadcasting": "self.version",
                 "illuminate/bus": "self.version",
                 "illuminate/cache": "self.version",
+                "illuminate/collections": "self.version",
                 "illuminate/config": "self.version",
                 "illuminate/console": "self.version",
                 "illuminate/container": "self.version",
@@ -458,6 +706,7 @@
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
                 "illuminate/log": "self.version",
+                "illuminate/macroable": "self.version",
                 "illuminate/mail": "self.version",
                 "illuminate/notifications": "self.version",
                 "illuminate/pagination": "self.version",
@@ -476,15 +725,14 @@
                 "aws/aws-sdk-php": "^3.0",
                 "doctrine/dbal": "^2.6",
                 "filp/whoops": "^2.4",
-                "guzzlehttp/guzzle": "^6.3.1|^7.0",
+                "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
                 "league/flysystem-cached-adapter": "^1.0",
                 "mockery/mockery": "^1.3.1",
-                "moontoast/math": "^1.1",
-                "orchestra/testbench-core": "^5.0",
+                "orchestra/testbench-core": "^6.0",
                 "pda/pheanstalk": "^4.0",
                 "phpunit/phpunit": "^8.4|^9.0",
                 "predis/predis": "^1.1.1",
-                "symfony/cache": "^5.0"
+                "symfony/cache": "^5.1"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.0).",
@@ -497,37 +745,42 @@
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
                 "filp/whoops": "Required for friendly error pages in development (^2.4).",
                 "fzaninotto/faker": "Required to use the eloquent factory builder (^1.9.1).",
-                "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.3.1|^7.0).",
+                "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.5.5|^7.0.1).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
                 "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
                 "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
                 "mockery/mockery": "Required to use mocking (^1.3.1).",
-                "moontoast/math": "Required to use ordered UUIDs (^1.1).",
                 "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
                 "phpunit/phpunit": "Required to use assertions and run tests (^8.4|^9.0).",
                 "predis/predis": "Required to use the predis connector (^1.1.2).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^5.0).",
-                "symfony/filesystem": "Required to create relative storage directory symbolic links (^5.0).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^5.1).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1).",
                 "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
                 "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.x-dev"
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
                 "files": [
+                    "src/Illuminate/Collections/helpers.php",
+                    "src/Illuminate/Events/functions.php",
                     "src/Illuminate/Foundation/helpers.php",
                     "src/Illuminate/Support/helpers.php"
                 ],
                 "psr-4": {
-                    "Illuminate\\": "src/Illuminate/"
+                    "Illuminate\\": "src/Illuminate/",
+                    "Illuminate\\Support\\": [
+                        "src/Illuminate/Macroable/",
+                        "src/Illuminate/Collections/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -546,7 +799,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2020-09-17T14:23:26+00:00"
+            "time": "2020-09-22T13:42:02+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -1276,6 +1529,105 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.1.3",
             "source": {
@@ -1441,6 +1793,46 @@
                 "shell"
             ],
             "time": "2020-05-03T19:32:03+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -3460,37 +3852,39 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v4.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "572af79d913627a9d70374d27a6f5d689a35de32"
+                "reference": "fba64139db67123c7a57072e5f8d3db10d160b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/572af79d913627a9d70374d27a6f5d689a35de32",
-                "reference": "572af79d913627a9d70374d27a6f5d689a35de32",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/fba64139db67123c7a57072e5f8d3db10d160b66",
+                "reference": "fba64139db67123c7a57072e5f8d3db10d160b66",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0 || ^8.0",
-                "phpoption/phpoption": "^1.7.3",
-                "symfony/polyfill-ctype": "^1.17"
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.0.1",
+                "php": "^7.1.3 || ^8.0",
+                "phpoption/phpoption": "^1.7.4",
+                "symfony/polyfill-ctype": "^1.17",
+                "symfony/polyfill-mbstring": "^1.17",
+                "symfony/polyfill-php80": "^1.17"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-filter": "*",
-                "ext-pcre": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7.27 || ^6.5.6 || ^7.0"
+                "phpunit/phpunit": "^7.5.20 || ^8.5.2 || ^9.0"
             },
             "suggest": {
-                "ext-filter": "Required to use the boolean validator.",
-                "ext-pcre": "Required to use most of the library."
+                "ext-filter": "Required to use the boolean validator."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
@@ -3520,7 +3914,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2020-07-14T19:22:52+00:00"
+            "time": "2020-09-14T15:57:31+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -4134,35 +4528,35 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v4.2.0",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "d50490417eded97be300a92cd7df7badc37a9018"
+                "reference": "4a343299054e9368d0db4a982a780cc4ffa12707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/d50490417eded97be300a92cd7df7badc37a9018",
-                "reference": "d50490417eded97be300a92cd7df7badc37a9018",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/4a343299054e9368d0db4a982a780cc4ffa12707",
+                "reference": "4a343299054e9368d0db4a982a780cc4ffa12707",
                 "shasum": ""
             },
             "require": {
                 "facade/ignition-contracts": "^1.0",
-                "filp/whoops": "^2.4",
-                "php": "^7.2.5",
+                "filp/whoops": "^2.7.2",
+                "php": "^7.3",
                 "symfony/console": "^5.0"
             },
             "require-dev": {
-                "facade/ignition": "^2.0",
-                "fideloper/proxy": "^4.2",
-                "friendsofphp/php-cs-fixer": "^2.16",
-                "fruitcake/laravel-cors": "^1.0",
-                "laravel/framework": "^7.0",
-                "laravel/tinker": "^2.0",
-                "nunomaduro/larastan": "^0.5",
-                "orchestra/testbench": "^5.0",
-                "phpstan/phpstan": "^0.12.3",
-                "phpunit/phpunit": "^8.5.1 || ^9.0"
+                "fideloper/proxy": "^4.4.0",
+                "friendsofphp/php-cs-fixer": "^2.16.4",
+                "fruitcake/laravel-cors": "^2.0.1",
+                "laravel/framework": "^8.0",
+                "laravel/tinker": "^2.4.1",
+                "nunomaduro/larastan": "^0.6.2",
+                "nunomaduro/mock-final-classes": "^1.0",
+                "orchestra/testbench": "^6.0",
+                "phpstan/phpstan": "^0.12.36",
+                "phpunit/phpunit": "^9.3.3"
             },
             "type": "library",
             "extra": {
@@ -4200,32 +4594,33 @@
                 "php",
                 "symfony"
             ],
-            "time": "2020-04-04T19:56:08+00:00"
+            "time": "2020-08-27T18:58:22+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -4255,24 +4650,24 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
+            "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/c6bb6825def89e0a32220f88337f8ceaf1975fa0",
+                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4302,7 +4697,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "time": "2020-06-27T14:39:04+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4515,40 +4910,44 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.10",
+            "version": "9.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
+                "reference": "c9394cb9d07ecfa9351b96f2e296bad473195f4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
-                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c9394cb9d07ecfa9351b96f2e296bad473195f4d",
+                "reference": "c9394cb9d07ecfa9351b96f2e296bad473195f4d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.1",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.8",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2.2"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-xdebug": "^2.7.2"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "9.1-dev"
                 }
             },
             "autoload": {
@@ -4574,32 +4973,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-11-20T13:55:58+00:00"
+            "time": "2020-09-19T05:29:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "25fefc5b19835ca653877fe081644a3f8c1d915e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/25fefc5b19835ca653877fe081644a3f8c1d915e",
+                "reference": "25fefc5b19835ca653877fe081644a3f8c1d915e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4624,26 +5023,87 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "time": "2020-07-11T05:18:21+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "7a85b66acc48cacffdf87dadd3694e7123674298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7a85b66acc48cacffdf87dadd3694e7123674298",
+                "reference": "7a85b66acc48cacffdf87dadd3694e7123674298",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2020-08-06T07:04:15+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "6ff9c8ea4d3212b88fcf74e25e516e2c51c99324"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/6ff9c8ea4d3212b88fcf74e25e516e2c51c99324",
+                "reference": "6ff9c8ea4d3212b88fcf74e25e516e2c51c99324",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -4665,32 +5125,32 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2020-06-26T11:55:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "cc49734779cbb302bf51a44297dab8c4bbf941e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/cc49734779cbb302bf51a44297dab8c4bbf941e7",
+                "reference": "cc49734779cbb302bf51a44297dab8c4bbf941e7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4714,106 +5174,59 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "abandoned": true,
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2020-06-26T11:58:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.8",
+            "version": "9.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997"
+                "reference": "919333f2d046a89f9238f15d09f17a8f0baa5cc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34c18baa6a44f1d1fbf0338907139e9dce95b997",
-                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/919333f2d046a89f9238f15d09f17a8f0baa5cc2",
+                "reference": "919333f2d046a89f9238f15d09f17a8f0baa5cc2",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.2.0",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.9.1",
-                "phar-io/manifest": "^1.0.3",
-                "phar-io/version": "^2.0.1",
-                "php": "^7.2",
-                "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.7",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1.2",
-                "sebastian/comparator": "^3.0.2",
-                "sebastian/diff": "^3.0.2",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/exporter": "^3.1.1",
-                "sebastian/global-state": "^3.0.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0.1",
-                "sebastian/type": "^1.1.3",
-                "sebastian/version": "^2.0.1"
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.11.1",
+                "phpunit/php-code-coverage": "^9.1.5",
+                "phpunit/php-file-iterator": "^3.0.4",
+                "phpunit/php-invoker": "^3.1",
+                "phpunit/php-text-template": "^2.0.2",
+                "phpunit/php-timer": "^5.0.1",
+                "sebastian/cli-parser": "^1.0",
+                "sebastian/code-unit": "^1.0.5",
+                "sebastian/comparator": "^4.0.3",
+                "sebastian/diff": "^4.0.2",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/exporter": "^4.0.2",
+                "sebastian/global-state": "^5.0",
+                "sebastian/object-enumerator": "^4.0.2",
+                "sebastian/resource-operations": "^3.0.2",
+                "sebastian/type": "^2.2.1",
+                "sebastian/version": "^3.0.1"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -4821,12 +5234,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.5-dev"
+                    "dev-master": "9.3-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4847,7 +5263,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-06-22T07:06:58+00:00"
+            "time": "2020-09-12T09:34:39+00:00"
         },
         {
             "name": "scrivo/highlight.php",
@@ -4919,29 +5335,121 @@
             "time": "2020-08-27T03:24:44+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2a4a38c56e62f7295bedb8b1b7439ad523d4ea82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2a4a38c56e62f7295bedb8b1b7439ad523d4ea82",
+                "reference": "2a4a38c56e62f7295bedb8b1b7439ad523d4ea82",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "time": "2020-08-12T10:49:21+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "c1e2df332c905079980b119c4db103117e5e5c90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/c1e2df332c905079980b119c4db103117e5e5c90",
+                "reference": "c1e2df332c905079980b119c4db103117e5e5c90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "time": "2020-06-26T12:50:45+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ee51f9bb0c6d8a43337055db3120829fa14da819"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ee51f9bb0c6d8a43337055db3120829fa14da819",
+                "reference": "ee51f9bb0c6d8a43337055db3120829fa14da819",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4961,34 +5469,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2020-06-26T12:04:00+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "dcc580eadfaa4e7f9d2cf9ae1922134ea962e14f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dcc580eadfaa4e7f9d2cf9ae1922134ea962e14f",
+                "reference": "dcc580eadfaa4e7f9d2cf9ae1922134ea962e14f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": "^7.3 || ^8.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5001,6 +5509,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -5012,10 +5524,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -5025,33 +5533,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "time": "2020-06-26T12:05:46+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.2",
+            "name": "sebastian/complexity",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "33fcd6a26656c6546f70871244ecba4b4dced097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/33fcd6a26656c6546f70871244ecba4b4dced097",
+                "reference": "33fcd6a26656c6546f70871244ecba4b4dced097",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "nikic/php-parser": "^4.7",
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -5065,12 +5573,59 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "time": "2020-07-25T14:01:34+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113",
+                "reference": "1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -5081,27 +5636,27 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "time": "2020-06-30T04:46:02+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "0a757cab9d5b7ef49a619f1143e6c9c1bc0fe9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/0a757cab9d5b7ef49a619f1143e6c9c1bc0fe9d2",
+                "reference": "0a757cab9d5b7ef49a619f1143e6c9c1bc0fe9d2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -5109,7 +5664,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5134,34 +5689,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "time": "2020-06-26T12:07:24+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "571d721db4aec847a0e59690b954af33ebf9f023"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/571d721db4aec847a0e59690b954af33ebf9f023",
+                "reference": "571d721db4aec847a0e59690b954af33ebf9f023",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3 || ^8.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5201,30 +5756,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "time": "2020-06-26T12:08:55+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
+                "reference": "22ae663c951bdc39da96603edc3239ed3a299097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
-                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/22ae663c951bdc39da96603edc3239ed3a299097",
+                "reference": "22ae663c951bdc39da96603edc3239ed3a299097",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3 || ^8.0",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -5232,7 +5787,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5255,34 +5810,81 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2019-02-01T05:30:01+00:00"
+            "time": "2020-08-07T04:09:03+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e02bf626f404b5daec382a7b8a6a4456e49017e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e02bf626f404b5daec382a7b8a6a4456e49017e5",
+                "reference": "e02bf626f404b5daec382a7b8a6a4456e49017e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "time": "2020-07-22T18:33:42+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "074fed2d0a6d08e1677dd8ce9d32aecb384917b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/074fed2d0a6d08e1677dd8ce9d32aecb384917b8",
+                "reference": "074fed2d0a6d08e1677dd8ce9d32aecb384917b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5302,122 +5904,27 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "time": "2020-06-26T12:11:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "127a46f6b057441b201253526f81d5406d6c7840"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/127a46f6b057441b201253526f81d5406d6c7840",
+                "reference": "127a46f6b057441b201253526f81d5406d6c7840",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
@@ -5440,34 +5947,132 @@
                     "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2020-06-26T12:12:55+00:00"
         },
         {
-            "name": "sebastian/type",
-            "version": "1.1.3",
+            "name": "sebastian/recursion-context",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "062231bf61d2b9448c4fa5a7643b5e1829c11d63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
-                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/062231bf61d2b9448c4fa5a7643b5e1829c11d63",
+                "reference": "062231bf61d2b9448c4fa5a7643b5e1829c11d63",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2020-06-26T12:14:17+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0653718a5a629b065e91f774595267f8dc32e213"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0653718a5a629b065e91f774595267f8dc32e213",
+                "reference": "0653718a5a629b065e91f774595267f8dc32e213",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2020-06-26T12:16:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/86991e2b33446cd96e648c18bcdb1e95afb2c05a",
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -5488,29 +6093,29 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
-            "time": "2019-07-02T08:10:15+00:00"
+            "time": "2020-07-05T08:31:53+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "626586115d0ed31cb71483be55beb759b5af5a3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/626586115d0ed31cb71483be55beb759b5af5a3c",
+                "reference": "626586115d0ed31cb71483be55beb759b5af5a3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^7.3 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5531,7 +6136,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2020-06-26T12:18:43+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/database/factories/ElementFactory.php
+++ b/database/factories/ElementFactory.php
@@ -1,12 +1,28 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\Element;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(Element::class, function (Faker $faker) {
-    return [
-        'name' => $faker->word,
-    ];
-});
+class ElementFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Element::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word,
+        ];
+    }
+}

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -1,23 +1,39 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\Item;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(Item::class, function (Faker $faker) {
-    return [
-        'position' => $faker->unique()->randomNumber,
-        'name' => $faker->name,
-        'type' => $faker->word,
-        'description' => $faker->paragraph,
-        'menu_effect' => $faker->sentence,
-        'price' => $faker->numberBetween(1, 50000),
-        'value' => $faker->numberBetween(1, 50000),
-        'haggle' => $faker->numberBetween(1, 50000),
-        'sell_high' => $faker->numberBetween(1, 50000),
-        'used_in_menu' => $faker->boolean,
-        'used_in_battle' => $faker->boolean,
-        'notes' => $faker->sentence,
-    ];
-});
+class ItemFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Item::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'position' => $this->faker->unique()->randomNumber,
+            'name' => $this->faker->name,
+            'type' => $this->faker->word,
+            'description' => $this->faker->paragraph,
+            'menu_effect' => $this->faker->sentence,
+            'price' => $this->faker->numberBetween(1, 50000),
+            'value' => $this->faker->numberBetween(1, 50000),
+            'haggle' => $this->faker->numberBetween(1, 50000),
+            'sell_high' => $this->faker->numberBetween(1, 50000),
+            'used_in_menu' => $this->faker->boolean,
+            'used_in_battle' => $this->faker->boolean,
+            'notes' => $this->faker->sentence,
+        ];
+    }
+}

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -1,15 +1,31 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\Location;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(Location::class, function (Faker $faker) {
-    return [
-        'name' => $faker->word,
-        'region_id' => null,
-        'description' => $faker->paragraph,
-        'area' => $faker->word,
-    ];
-});
+class LocationFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Location::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word,
+            'region_id' => null,
+            'description' => $this->faker->paragraph,
+            'area' => $this->faker->word,
+        ];
+    }
+}

--- a/database/factories/SeedRankFactory.php
+++ b/database/factories/SeedRankFactory.php
@@ -1,13 +1,29 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\SeedRank;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(SeedRank::class, function (Faker $faker) {
-    return [
-        'rank' => $faker->numberBetween(1, 30),
-        'salary' => $faker->numberBetween(500, 30000),
-    ];
-});
+class SeedRankFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SeedRank::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'rank' => $this->faker->numberBetween(1, 30),
+            'salary' => $this->faker->numberBetween(500, 30000),
+        ];
+    }
+}

--- a/database/factories/SeedTestFactory.php
+++ b/database/factories/SeedTestFactory.php
@@ -1,12 +1,28 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\SeedTest;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(SeedTest::class, function (Faker $faker) {
-    return [
-        'level' => $faker->numberBetween(1, 30),
-    ];
-});
+class SeedTestFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SeedTest::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'level' => $this->faker->numberBetween(1, 30),
+        ];
+    }
+}

--- a/database/factories/StatFactory.php
+++ b/database/factories/StatFactory.php
@@ -1,13 +1,29 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\Stat;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(Stat::class, function (Faker $faker) {
-    return [
-        'name' => $faker->word,
-        'abbreviation' => $faker->word,
-    ];
-});
+class StatFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Stat::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word,
+            'abbreviation' => $this->faker->word,
+        ];
+    }
+}

--- a/database/factories/StatusEffectFactory.php
+++ b/database/factories/StatusEffectFactory.php
@@ -1,14 +1,30 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\StatusEffect;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(StatusEffect::class, function (Faker $faker) {
-    return [
-        'name' => $faker->word,
-        'type' => $faker->word,
-        'description' => $faker->paragraph,
-    ];
-});
+class StatusEffectFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = StatusEffect::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word,
+            'type' => $this->faker->word,
+            'description' => $this->faker->paragraph,
+        ];
+    }
+}

--- a/database/factories/TestQuestionFactory.php
+++ b/database/factories/TestQuestionFactory.php
@@ -1,15 +1,31 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
 use App\Models\TestQuestion;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-$factory->define(TestQuestion::class, function (Faker $faker) {
-    return [
-        'seed_test_id' => null,
-        'question_number' => $faker->numberBetween(1, 10),
-        'question' => $faker->paragraph,
-        'answer' => $faker->randomElement(['yes', 'no']),
-    ];
-});
+class TestQuestionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TestQuestion::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'seed_test_id' => null,
+            'question_number' => $this->faker->numberBetween(1, 10),
+            'question' => $this->faker->paragraph,
+            'answer' => $this->faker->randomElement(['yes', 'no']),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,27 +1,33 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
-use App\User;
-use Faker\Generator as Faker;
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
-/*
-|--------------------------------------------------------------------------
-| Model Factories
-|--------------------------------------------------------------------------
-|
-| This directory should contain each of the model factory definitions for
-| your application. Factories provide a convenient way to generate new
-| model instances for testing / seeding your application's database.
-|
-*/
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
 
-$factory->define(User::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'email' => $faker->unique()->safeEmail,
-        'email_verified_at' => now(),
-        'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-        'remember_token' => Str::random(10),
-    ];
-});
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name,
+            'email' => $this->faker->unique()->safeEmail,
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ];
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder

--- a/database/seeds/ElementsTableSeeder.php
+++ b/database/seeds/ElementsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\Element;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;

--- a/database/seeds/ItemsTableSeeder.php
+++ b/database/seeds/ItemsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\Item;
 use App\Models\StatusEffect;
 use Carbon\Carbon;

--- a/database/seeds/LocationsTableSeeder.php
+++ b/database/seeds/LocationsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\Location;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;

--- a/database/seeds/SeedRanksTableSeeder.php
+++ b/database/seeds/SeedRanksTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\SeedRank;
 use Illuminate\Database\Seeder;
 use Webpatser\Uuid\Uuid;

--- a/database/seeds/SeedTestsTableSeeder.php
+++ b/database/seeds/SeedTestsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\SeedTest;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;

--- a/database/seeds/StatsTableSeeder.php
+++ b/database/seeds/StatsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\Stat;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;

--- a/database/seeds/StatusEffectsTableSeeder.php
+++ b/database/seeds/StatusEffectsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\StatusEffect;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;

--- a/database/seeds/TestQuestionsTableSeeder.php
+++ b/database/seeds/TestQuestionsTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use App\Models\SeedTest;
 use App\Models\TestQuestion;
 use Carbon\Carbon;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,46 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-            <!-- Exclude the default, unmodified Laravel files until they are used. -->
-            <!-- These files do not have code coverage out of the box -->
-            <exclude>
-                <directory suffix=".php">./app/Http/Controllers/Auth</directory>
-                <directory suffix=".php">./app/Http/Middleware</directory>
-                <directory suffix=".php">./app/Providers</directory>
-                <file>./app/Exceptions/Handler.php</file>
-                <file>./app/Console/Kernel.php</file>
-                <file>./app/Http/Controllers/Controller.php</file>
-                <file>./app/Http/Kernel.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <server name="APP_ENV" value="testing"/>
-        <server name="BCRYPT_ROUNDS" value="4"/>
-        <server name="CACHE_DRIVER" value="array"/>
-        <server name="MAIL_DRIVER" value="array"/>
-        <server name="QUEUE_CONNECTION" value="sync"/>
-        <server name="SESSION_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+    <exclude>
+      <!-- Exclude the default, unmodified Laravel files until they are used. -->
+      <!-- These files do not have code coverage out of the box -->
+      <directory suffix=".php">./app/Http/Controllers/Auth</directory>
+      <directory suffix=".php">./app/Http/Middleware</directory>
+      <directory suffix=".php">./app/Providers</directory>
+      <file>./app/Exceptions/Handler.php</file>
+      <file>./app/Console/Kernel.php</file>
+      <file>./app/Http/Controllers/Controller.php</file>
+      <file>./app/Http/Kernel.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+    <server name="BCRYPT_ROUNDS" value="4"/>
+    <server name="CACHE_DRIVER" value="array"/>
+    <server name="MAIL_DRIVER" value="array"/>
+    <server name="QUEUE_CONNECTION" value="sync"/>
+    <server name="SESSION_DRIVER" value="array"/>
+  </php>
 </phpunit>

--- a/tests/Feature/Routes/ElementRoutesTest.php
+++ b/tests/Feature/Routes/ElementRoutesTest.php
@@ -13,7 +13,7 @@ class ElementRoutesTest extends TestCase
     /** @test */
     public function it_returns_a_list_of_elements()
     {
-        $elements = factory(Element::class, 10)->create();
+        $elements = Element::factory()->count(10)->create();
 
         $response = $this->get('/api/elements');
 
@@ -24,7 +24,7 @@ class ElementRoutesTest extends TestCase
     /** @test */
     public function it_returns_an_individual_element()
     {
-        $element = factory(Element::class)->create();
+        $element = Element::factory()->create();
 
         $response = $this->get("/api/elements/{$element->id}");
 
@@ -43,9 +43,9 @@ class ElementRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $response = $this->get('/api/elements?name=thunder');
 
@@ -57,9 +57,9 @@ class ElementRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_like_operator()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $response = $this->get('/api/elements?name=like:er');
 
@@ -72,9 +72,9 @@ class ElementRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_not_operator()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $response = $this->get('/api/elements?name=not:water');
 

--- a/tests/Feature/Routes/ItemRoutesTest.php
+++ b/tests/Feature/Routes/ItemRoutesTest.php
@@ -13,7 +13,7 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_will_return_a_list_of_items()
     {
-        factory(Item::class, 10)->create();
+        Item::factory()->count(10)->create();
 
         $response = $this->get('/api/items');
 
@@ -24,7 +24,7 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_will_return_an_individual_item()
     {
-        $item = factory(Item::class)->create();
+        $item = Item::factory()->create();
 
         $response = $this->get("/api/items/{$item->name}");
 
@@ -43,10 +43,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_position_column()
     {
-        factory(Item::class)->create(['position' => 1]);
-        factory(Item::class)->create(['position' => 2]);
-        factory(Item::class)->create(['position' => 3]);
-        factory(Item::class)->create(['position' => 13]);
+        Item::factory()->create(['position' => 1]);
+        Item::factory()->create(['position' => 2]);
+        Item::factory()->create(['position' => 3]);
+        Item::factory()->create(['position' => 13]);
 
         // Equals
         $response = $this->get('/api/items?position=1');
@@ -108,10 +108,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_name_column()
     {
-        factory(Item::class)->create(['name' => 'Potion']);
-        factory(Item::class)->create(['name' => 'Potion+']);
-        factory(Item::class)->create(['name' => 'Elixir']);
-        factory(Item::class)->create(['name' => 'Phoenix Down']);
+        Item::factory()->create(['name' => 'Potion']);
+        Item::factory()->create(['name' => 'Potion+']);
+        Item::factory()->create(['name' => 'Elixir']);
+        Item::factory()->create(['name' => 'Phoenix Down']);
 
         // Equals
         $response = $this->get('/api/items?name=Potion');
@@ -141,10 +141,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_type_column()
     {
-        factory(Item::class)->create(['type' => 'Medicine']);
-        factory(Item::class)->create(['type' => 'Ammo']);
-        factory(Item::class)->create(['type' => 'Tool']);
-        factory(Item::class)->create(['type' => 'Magazine']);
+        Item::factory()->create(['type' => 'Medicine']);
+        Item::factory()->create(['type' => 'Ammo']);
+        Item::factory()->create(['type' => 'Tool']);
+        Item::factory()->create(['type' => 'Magazine']);
 
         // Equals
         $response = $this->get('/api/items?type=Medicine');
@@ -174,10 +174,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_description_column()
     {
-        factory(Item::class)->create(['description' => 'Restores HP by 200']);
-        factory(Item::class)->create(['description' => 'Raises HP']);
-        factory(Item::class)->create(['description' => 'Poisonous monster fang']);
-        factory(Item::class)->create(['description' => 'Cures Poison']);
+        Item::factory()->create(['description' => 'Restores HP by 200']);
+        Item::factory()->create(['description' => 'Raises HP']);
+        Item::factory()->create(['description' => 'Poisonous monster fang']);
+        Item::factory()->create(['description' => 'Cures Poison']);
 
         // Equals
         $response = $this->get('/api/items?description=Raises HP');
@@ -204,10 +204,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_menu_effect_column()
     {
-        factory(Item::class)->create(['menu_effect' => 'One party member']);
-        factory(Item::class)->create(['menu_effect' => 'One GF']);
-        factory(Item::class)->create(['menu_effect' => 'All party members']);
-        factory(Item::class)->create(['menu_effect' => null]);
+        Item::factory()->create(['menu_effect' => 'One party member']);
+        Item::factory()->create(['menu_effect' => 'One GF']);
+        Item::factory()->create(['menu_effect' => 'All party members']);
+        Item::factory()->create(['menu_effect' => null]);
 
         // Equals
         $response = $this->get('/api/items?menu_effect=One party member');
@@ -233,10 +233,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_price_column()
     {
-        factory(Item::class)->create(['price' => 25]);
-        factory(Item::class)->create(['price' => 125]);
-        factory(Item::class)->create(['price' => 750]);
-        factory(Item::class)->create(['price' => 20000]);
+        Item::factory()->create(['price' => 25]);
+        Item::factory()->create(['price' => 125]);
+        Item::factory()->create(['price' => 750]);
+        Item::factory()->create(['price' => 20000]);
 
         // Equals
         $response = $this->get('/api/items?price=750');
@@ -291,10 +291,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_value_column()
     {
-        factory(Item::class)->create(['value' => 25]);
-        factory(Item::class)->create(['value' => 125]);
-        factory(Item::class)->create(['value' => 750]);
-        factory(Item::class)->create(['value' => 20000]);
+        Item::factory()->create(['value' => 25]);
+        Item::factory()->create(['value' => 125]);
+        Item::factory()->create(['value' => 750]);
+        Item::factory()->create(['value' => 20000]);
 
         // Equals
         $response = $this->get('/api/items?value=750');
@@ -349,10 +349,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_haggle_column()
     {
-        factory(Item::class)->create(['haggle' => 25]);
-        factory(Item::class)->create(['haggle' => 125]);
-        factory(Item::class)->create(['haggle' => 750]);
-        factory(Item::class)->create(['haggle' => 20000]);
+        Item::factory()->create(['haggle' => 25]);
+        Item::factory()->create(['haggle' => 125]);
+        Item::factory()->create(['haggle' => 750]);
+        Item::factory()->create(['haggle' => 20000]);
 
         // Equals
         $response = $this->get('/api/items?haggle=750');
@@ -407,10 +407,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_sell_high_column()
     {
-        factory(Item::class)->create(['sell_high' => 25]);
-        factory(Item::class)->create(['sell_high' => 125]);
-        factory(Item::class)->create(['sell_high' => 750]);
-        factory(Item::class)->create(['sell_high' => 20000]);
+        Item::factory()->create(['sell_high' => 25]);
+        Item::factory()->create(['sell_high' => 125]);
+        Item::factory()->create(['sell_high' => 750]);
+        Item::factory()->create(['sell_high' => 20000]);
 
         // Equals
         $response = $this->get('/api/items?sell_high=750');
@@ -465,9 +465,9 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_used_in_menu_column()
     {
-        factory(Item::class)->create(['used_in_menu' => true]);
-        factory(Item::class)->create(['used_in_menu' => false]);
-        factory(Item::class)->create(['used_in_menu' => true]);
+        Item::factory()->create(['used_in_menu' => true]);
+        Item::factory()->create(['used_in_menu' => false]);
+        Item::factory()->create(['used_in_menu' => true]);
 
         // Equals
         $response = $this->get('/api/items?used_in_menu=true');
@@ -491,9 +491,9 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_used_in_battle_column()
     {
-        factory(Item::class)->create(['used_in_battle' => true]);
-        factory(Item::class)->create(['used_in_battle' => false]);
-        factory(Item::class)->create(['used_in_battle' => true]);
+        Item::factory()->create(['used_in_battle' => true]);
+        Item::factory()->create(['used_in_battle' => false]);
+        Item::factory()->create(['used_in_battle' => true]);
 
         // Equals
         $response = $this->get('/api/items?used_in_battle=true');
@@ -517,10 +517,10 @@ class ItemRoutesTest extends TestCase
     /** @test */
     public function it_can_filter_items_by_the_notes_column_1()
     {
-        factory(Item::class)->create(['notes' => 'GF Compatibility: Ifrit +1']);
-        factory(Item::class)->create(['notes' => 'GF Compatibility: Ifrit +3']);
-        factory(Item::class)->create(['notes' => 'GF Compatibility: Shiva +3']);
-        factory(Item::class)->create(['notes' => 'All Guardian Forces +20']);
+        Item::factory()->create(['notes' => 'GF Compatibility: Ifrit +1']);
+        Item::factory()->create(['notes' => 'GF Compatibility: Ifrit +3']);
+        Item::factory()->create(['notes' => 'GF Compatibility: Shiva +3']);
+        Item::factory()->create(['notes' => 'All Guardian Forces +20']);
 
         // Equals
         $response = $this->get('/api/items?notes=All Guardian Forces +20');

--- a/tests/Feature/Routes/LocationRoutesTest.php
+++ b/tests/Feature/Routes/LocationRoutesTest.php
@@ -13,7 +13,7 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_returns_a_list_of_locations()
     {
-        $locations = factory(Location::class, 10)->create();
+        $locations = Location::factory()->count(10)->create();
 
         $response = $this->get('/api/locations');
 
@@ -24,7 +24,7 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_returns_an_individual_location()
     {
-        $location = factory(Location::class)->create();
+        $location = Location::factory()->create();
 
         $response = $this->get("/api/locations/{$location->id}");
 
@@ -35,12 +35,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_relations_on_individual_records()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -58,12 +58,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_relation_properties_on_individual_records()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -85,12 +85,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_properties_on_individual_records()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -121,9 +121,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar Region' ]);
 
         $response = $this->get('/api/locations?name=Balamb Region');
 
@@ -135,9 +135,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_like_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar Region' ]);
 
         $response = $this->get('/api/locations?name=like:al');
 
@@ -150,9 +150,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_not_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar Region' ]);
 
         $response = $this->get('/api/locations?name=not:Balamb Region');
 
@@ -165,9 +165,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_area_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $response = $this->get('/api/locations?area=Alcauld Plains');
 
@@ -179,9 +179,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_area_column_can_be_filtered_by_the_like_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $response = $this->get('/api/locations?area=like:Plains');
 
@@ -194,9 +194,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_area_column_can_be_filtered_by_the_not_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $response = $this->get('/api/locations?area=not:Alcauld Plains');
 
@@ -209,9 +209,9 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function the_name_and_area_columns_can_both_be_filtered_together()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Garden', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Garden', 'area' => 'Monterosa Plateau' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb Garden', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Garden', 'area' => 'Monterosa Plateau' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $response = $this->get('/api/locations?name=like:Garden&area=not:Alcauld Plains');
 
@@ -226,12 +226,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_region_without_additional_filters()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -250,12 +250,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_entire_region_relation()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -274,12 +274,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_name_column_on_the_region_relation()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -302,12 +302,12 @@ class LocationRoutesTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_columns_explicitly()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',

--- a/tests/Feature/Routes/SeedRankRoutesTest.php
+++ b/tests/Feature/Routes/SeedRankRoutesTest.php
@@ -13,7 +13,7 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function it_returns_a_list_of_seed_ranks()
     {
-        $seedRanks = factory(SeedRank::class, 10)->create();
+        $seedRanks = SeedRank::factory()->count(10)->create();
 
         $response = $this->get('/api/seed-ranks');
 
@@ -24,7 +24,7 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function it_returns_an_individual_seed_rank()
     {
-        $seedRank = factory(SeedRank::class)->create();
+        $seedRank = SeedRank::factory()->create();
 
         $response = $this->get("/api/seed-ranks/{$seedRank->id}");
 
@@ -43,9 +43,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=5');
 
@@ -57,9 +57,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_gt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=gt:5');
 
@@ -71,9 +71,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_gte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=gte:5');
 
@@ -86,9 +86,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_lt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=lt:5');
 
@@ -100,9 +100,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_lte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=lte:5');
 
@@ -115,9 +115,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_like_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=like:1');
 
@@ -130,9 +130,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_not_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $response = $this->get('/api/seed-ranks?rank=not:10');
 
@@ -145,9 +145,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=3000');
 
@@ -159,9 +159,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_gt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=gt:3000');
 
@@ -173,9 +173,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_gte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=gte:3000');
 
@@ -188,9 +188,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_lt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=lt:3000');
 
@@ -202,9 +202,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_lte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=lte:3000');
 
@@ -217,9 +217,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_like_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=like:000');
 
@@ -232,9 +232,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_not_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=not:3000');
 
@@ -247,9 +247,9 @@ class SeedRankRoutesTest extends TestCase
     /** @test */
     public function the_name_and_salary_columns_can_both_be_filtered_together()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $response = $this->get('/api/seed-ranks?salary=not:8000');
 

--- a/tests/Feature/Routes/SeedTestRoutesTest.php
+++ b/tests/Feature/Routes/SeedTestRoutesTest.php
@@ -14,7 +14,7 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_seed_tests()
     {
-        $seedTests = factory(SeedTest::class, 10)->create();
+        $seedTests = SeedTest::factory()->count(10)->create();
 
         $response = $this->get('/api/seed-tests');
 
@@ -25,7 +25,7 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_returns_an_individual_seed_test()
     {
-        $seedTest = factory(SeedTest::class)->create();
+        $seedTest = SeedTest::factory()->create();
 
         $response = $this->get("/api/seed-tests/{$seedTest->id}");
 
@@ -36,10 +36,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_relations_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -59,10 +59,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_relation_properties_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -86,10 +86,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_properties_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -122,9 +122,9 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function the_level_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(SeedTest::class)->create([ 'level' => 1 ]);
-        factory(SeedTest::class)->create([ 'level' => 5 ]);
-        factory(SeedTest::class)->create([ 'level' => 10 ]);
+        SeedTest::factory()->create([ 'level' => 1 ]);
+        SeedTest::factory()->create([ 'level' => 5 ]);
+        SeedTest::factory()->create([ 'level' => 10 ]);
 
         $response = $this->get('/api/seed-tests?level=1');
 
@@ -136,9 +136,9 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function the_level_column_can_be_filtered_by_the_like_operator()
     {
-        factory(SeedTest::class)->create([ 'level' => 1 ]);
-        factory(SeedTest::class)->create([ 'level' => 5 ]);
-        factory(SeedTest::class)->create([ 'level' => 10 ]);
+        SeedTest::factory()->create([ 'level' => 1 ]);
+        SeedTest::factory()->create([ 'level' => 5 ]);
+        SeedTest::factory()->create([ 'level' => 10 ]);
 
         $response = $this->get('/api/seed-tests?level=like:1');
 
@@ -151,9 +151,9 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function the_level_column_can_be_filtered_by_the_not_operator()
     {
-        factory(SeedTest::class)->create([ 'level' => 1 ]);
-        factory(SeedTest::class)->create([ 'level' => 5 ]);
-        factory(SeedTest::class)->create([ 'level' => 10 ]);
+        SeedTest::factory()->create([ 'level' => 1 ]);
+        SeedTest::factory()->create([ 'level' => 5 ]);
+        SeedTest::factory()->create([ 'level' => 10 ]);
 
         $response = $this->get('/api/seed-tests?level=not:10');
 
@@ -166,10 +166,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_questions_without_additional_filters()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -189,10 +189,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_question_number_column_on_the_questions_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -216,10 +216,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_question_column_on_the_questions_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -243,10 +243,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_answer_column_on_the_questions_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -270,10 +270,10 @@ class SeedTestRoutesTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_columns_explicitly()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',

--- a/tests/Feature/Routes/StatusEffectRoutesTest.php
+++ b/tests/Feature/Routes/StatusEffectRoutesTest.php
@@ -13,7 +13,7 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function it_returns_a_list_of_status_effects()
     {
-        $statusEffects = factory(StatusEffect::class, 10)->create();
+        $statusEffects = StatusEffect::factory()->count(10)->create();
 
         $response = $this->get('/api/status-effects');
 
@@ -24,7 +24,7 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function it_returns_an_individual_statusEffect()
     {
-        $statusEffect = factory(StatusEffect::class)->create();
+        $statusEffect = StatusEffect::factory()->create();
 
         $response = $this->get("/api/status-effects/{$statusEffect->id}");
 
@@ -43,9 +43,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?name=Death');
 
@@ -57,9 +57,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_like_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?name=like:le');
 
@@ -72,9 +72,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_not_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?name=not:Double');
 
@@ -87,9 +87,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_type_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?type=harmful');
 
@@ -102,9 +102,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_type_column_can_be_filtered_by_the_like_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?type=like:cial');
 
@@ -117,9 +117,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_type_column_can_be_filtered_by_the_not_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?type=not:beneficial');
 
@@ -132,9 +132,9 @@ class StatusEffectRoutesTest extends TestCase
     /** @test */
     public function the_name_and_type_columns_can_both_be_filtered_together()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $response = $this->get('/api/status-effects?name=like:Dou&type=like:ficial');
 

--- a/tests/Feature/Routes/TestQuestionRoutesTest.php
+++ b/tests/Feature/Routes/TestQuestionRoutesTest.php
@@ -14,7 +14,7 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_test_questions()
     {
-        $testQuestions = factory(TestQuestion::class, 10)->create();
+        $testQuestions = TestQuestion::factory()->count(10)->create();
 
         $response = $this->get('/api/test-questions');
 
@@ -25,7 +25,7 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function it_returns_an_individual_test_question()
     {
-        $testQuestion = factory(TestQuestion::class)->create();
+        $testQuestion = TestQuestion::factory()->create();
 
         $response = $this->get("/api/test-questions/{$testQuestion->id}");
 
@@ -36,10 +36,10 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function it_can_load_relations_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -57,10 +57,10 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function it_can_load_relation_properties_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -89,17 +89,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_filters_are_case_insensitive()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -116,17 +116,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -142,17 +142,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_lt_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -169,17 +169,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_lte_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -196,17 +196,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_gt_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -222,17 +222,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_gte_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -249,17 +249,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_like_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 10,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -276,17 +276,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_not_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -303,17 +303,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -329,17 +329,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_column_can_be_filtered_by_the_like_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -356,17 +356,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_question_column_can_be_filtered_by_the_not_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -383,17 +383,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_answer_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -410,17 +410,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_answer_column_can_be_filtered_by_the_like_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -437,17 +437,17 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function the_answer_column_can_be_filtered_by_the_not_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -463,10 +463,10 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_test_without_additional_filters()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -484,10 +484,10 @@ class TestQuestionRoutesTest extends TestCase
     /** @test */
     public function it_can_load_the_level_column_on_the_test_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 5,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',

--- a/tests/Unit/Controllers/ElementControllerTest.php
+++ b/tests/Unit/Controllers/ElementControllerTest.php
@@ -17,7 +17,7 @@ class ElementControllerTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_elements()
     {
-        $elements = factory(Element::class, 10)->create();
+        $elements = Element::factory()->count(10)->create();
 
         $elementController = new ElementController(new Element());
 
@@ -31,7 +31,7 @@ class ElementControllerTest extends TestCase
     /** @test */
     public function it_returns_an_individual_element()
     {
-        $element = factory(Element::class)->create();
+        $element = Element::factory()->create();
 
         $elementController = new ElementController(new Element());
 
@@ -49,7 +49,7 @@ class ElementControllerTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $element = factory(Element::class)->create();
+        $element = Element::factory()->create();
 
         $elementController = new ElementController(new Element());
 
@@ -59,9 +59,9 @@ class ElementControllerTest extends TestCase
     /** @test */
     public function the_filters_are_case_insensitive()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $request = new Request([ 'name' => 'FiRe' ]);
         $elementController = new ElementController(new Element());
@@ -74,9 +74,9 @@ class ElementControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $request = new Request([ 'name' => 'thunder' ]);
         $elementController = new ElementController(new Element());
@@ -89,9 +89,9 @@ class ElementControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_like_operator()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $request = new Request([ 'name' => 'like:er' ]);
         $elementController = new ElementController(new Element());
@@ -105,9 +105,9 @@ class ElementControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_not_operator()
     {
-        factory(Element::class)->create([ 'name' => 'fire' ]);
-        factory(Element::class)->create([ 'name' => 'water' ]);
-        factory(Element::class)->create([ 'name' => 'thunder' ]);
+        Element::factory()->create([ 'name' => 'fire' ]);
+        Element::factory()->create([ 'name' => 'water' ]);
+        Element::factory()->create([ 'name' => 'thunder' ]);
 
         $request = new Request([ 'name' => 'not:water' ]);
         $elementController = new ElementController(new Element());

--- a/tests/Unit/Controllers/ItemControllerTest.php
+++ b/tests/Unit/Controllers/ItemControllerTest.php
@@ -17,7 +17,7 @@ class ItemControllerTest extends TestCase
     /** @test */
     public function it_will_return_a_list_of_items()
     {
-        $items = factory(Item::class, 10)->create();
+        $items = Item::factory()->count(10)->create();
 
         $itemController = new ItemController(new Item());
 
@@ -31,7 +31,7 @@ class ItemControllerTest extends TestCase
     /** @test */
     public function it_will_return_an_individual_item()
     {
-        $item = factory(Item::class)->create();
+        $item = Item::factory()->create();
 
         $itemController = new ItemController(new Item());
 
@@ -58,10 +58,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_position_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['position' => 1]);
-        factory(Item::class)->create(['position' => 2]);
-        factory(Item::class)->create(['position' => 3]);
-        factory(Item::class)->create(['position' => 13]);
+        Item::factory()->create(['position' => 1]);
+        Item::factory()->create(['position' => 2]);
+        Item::factory()->create(['position' => 3]);
+        Item::factory()->create(['position' => 13]);
 
         // Equals
         $request = new Request(['position' => '1']);
@@ -124,10 +124,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_name_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['name' => 'Potion']);
-        factory(Item::class)->create(['name' => 'Potion+']);
-        factory(Item::class)->create(['name' => 'Elixir']);
-        factory(Item::class)->create(['name' => 'Phoenix Down']);
+        Item::factory()->create(['name' => 'Potion']);
+        Item::factory()->create(['name' => 'Potion+']);
+        Item::factory()->create(['name' => 'Elixir']);
+        Item::factory()->create(['name' => 'Phoenix Down']);
 
         // Equals
         $request = new Request(['name' => 'Potion']);
@@ -158,10 +158,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_type_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['type' => 'Medicine']);
-        factory(Item::class)->create(['type' => 'Ammo']);
-        factory(Item::class)->create(['type' => 'Tool']);
-        factory(Item::class)->create(['type' => 'Magazine']);
+        Item::factory()->create(['type' => 'Medicine']);
+        Item::factory()->create(['type' => 'Ammo']);
+        Item::factory()->create(['type' => 'Tool']);
+        Item::factory()->create(['type' => 'Magazine']);
 
         // Equals
         $request = new Request(['type' => 'Medicine']);
@@ -192,10 +192,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_description_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['description' => 'Restores HP by 200']);
-        factory(Item::class)->create(['description' => 'Raises HP']);
-        factory(Item::class)->create(['description' => 'Poisonous monster fang']);
-        factory(Item::class)->create(['description' => 'Cures Poison']);
+        Item::factory()->create(['description' => 'Restores HP by 200']);
+        Item::factory()->create(['description' => 'Raises HP']);
+        Item::factory()->create(['description' => 'Poisonous monster fang']);
+        Item::factory()->create(['description' => 'Cures Poison']);
 
         // Equals
         $request = new Request(['description' => 'Raises HP']);
@@ -226,10 +226,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_menu_effect_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['menu_effect' => 'One party member']);
-        factory(Item::class)->create(['menu_effect' => 'One GF']);
-        factory(Item::class)->create(['menu_effect' => 'All party members']);
-        factory(Item::class)->create(['menu_effect' => null]);
+        Item::factory()->create(['menu_effect' => 'One party member']);
+        Item::factory()->create(['menu_effect' => 'One GF']);
+        Item::factory()->create(['menu_effect' => 'All party members']);
+        Item::factory()->create(['menu_effect' => null]);
 
         // Equals
         $request = new Request(['menu_effect' => 'One party member']);
@@ -259,10 +259,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_price_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['price' => 25]);
-        factory(Item::class)->create(['price' => 125]);
-        factory(Item::class)->create(['price' => 750]);
-        factory(Item::class)->create(['price' => 20000]);
+        Item::factory()->create(['price' => 25]);
+        Item::factory()->create(['price' => 125]);
+        Item::factory()->create(['price' => 750]);
+        Item::factory()->create(['price' => 20000]);
 
         // Equals
         $request = new Request(['price' => 750]);
@@ -325,10 +325,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_value_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['value' => 25]);
-        factory(Item::class)->create(['value' => 125]);
-        factory(Item::class)->create(['value' => 750]);
-        factory(Item::class)->create(['value' => 20000]);
+        Item::factory()->create(['value' => 25]);
+        Item::factory()->create(['value' => 125]);
+        Item::factory()->create(['value' => 750]);
+        Item::factory()->create(['value' => 20000]);
 
         // Equals
         $request = new Request(['value' => 750]);
@@ -391,10 +391,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_haggle_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['haggle' => 25]);
-        factory(Item::class)->create(['haggle' => 125]);
-        factory(Item::class)->create(['haggle' => 750]);
-        factory(Item::class)->create(['haggle' => 20000]);
+        Item::factory()->create(['haggle' => 25]);
+        Item::factory()->create(['haggle' => 125]);
+        Item::factory()->create(['haggle' => 750]);
+        Item::factory()->create(['haggle' => 20000]);
 
         // Equals
         $request = new Request(['haggle' => 750]);
@@ -457,10 +457,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_sell_high_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['sell_high' => 25]);
-        factory(Item::class)->create(['sell_high' => 125]);
-        factory(Item::class)->create(['sell_high' => 750]);
-        factory(Item::class)->create(['sell_high' => 20000]);
+        Item::factory()->create(['sell_high' => 25]);
+        Item::factory()->create(['sell_high' => 125]);
+        Item::factory()->create(['sell_high' => 750]);
+        Item::factory()->create(['sell_high' => 20000]);
 
         // Equals
         $request = new Request(['sell_high' => 750]);
@@ -523,9 +523,9 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_used_in_menu_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['used_in_menu' => true]);
-        factory(Item::class)->create(['used_in_menu' => false]);
-        factory(Item::class)->create(['used_in_menu' => true]);
+        Item::factory()->create(['used_in_menu' => true]);
+        Item::factory()->create(['used_in_menu' => false]);
+        Item::factory()->create(['used_in_menu' => true]);
 
         // Equals
         $request = new Request(['used_in_menu' => 'true']);
@@ -553,9 +553,9 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_used_in_battle_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['used_in_battle' => true]);
-        factory(Item::class)->create(['used_in_battle' => false]);
-        factory(Item::class)->create(['used_in_battle' => true]);
+        Item::factory()->create(['used_in_battle' => true]);
+        Item::factory()->create(['used_in_battle' => false]);
+        Item::factory()->create(['used_in_battle' => true]);
 
         // Equals
         $request = new Request(['used_in_battle' => 'true']);
@@ -583,10 +583,10 @@ class ItemControllerTest extends TestCase
     public function it_can_filter_items_by_the_notes_column()
     {
         $item = new Item();
-        factory(Item::class)->create(['notes' => 'GF Compatibility: Ifrit +1']);
-        factory(Item::class)->create(['notes' => 'GF Compatibility: Ifrit +3']);
-        factory(Item::class)->create(['notes' => 'GF Compatibility: Shiva +3']);
-        factory(Item::class)->create(['notes' => 'All Guardian Forces +20']);
+        Item::factory()->create(['notes' => 'GF Compatibility: Ifrit +1']);
+        Item::factory()->create(['notes' => 'GF Compatibility: Ifrit +3']);
+        Item::factory()->create(['notes' => 'GF Compatibility: Shiva +3']);
+        Item::factory()->create(['notes' => 'All Guardian Forces +20']);
 
         // Equals
         $request = new Request(['notes' => 'All Guardian Forces +20']);

--- a/tests/Unit/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Controllers/LocationControllerTest.php
@@ -17,7 +17,7 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_locations()
     {
-        $locations = factory(Location::class, 10)->create();
+        $locations = Location::factory()->count(10)->create();
 
         $locationController = new LocationController(new Location());
 
@@ -31,7 +31,7 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_returns_an_individual_location()
     {
-        $location = factory(Location::class)->create();
+        $location = Location::factory()->create();
 
         $locationController = new LocationController(new Location());
 
@@ -47,12 +47,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_relations_on_individual_records()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -78,12 +78,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_relation_properties_on_individual_records()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -113,12 +113,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_properties_on_individual_records()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -151,7 +151,7 @@ class LocationControllerTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $location = factory(Location::class)->create();
+        $location = Location::factory()->create();
 
         $locationController = new LocationController(new Location());
 
@@ -161,9 +161,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_filters_are_case_insensitive()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar Region' ]);
 
         $request = new Request([ 'name' => 'galbadia region' ]);
         $locationController = new LocationController(new Location());
@@ -176,9 +176,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar Region' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar Region' ]);
 
         $request = new Request([ 'name' => 'Galbadia Region' ]);
         $locationController = new LocationController(new Location());
@@ -191,9 +191,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_like_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar' ]);
 
         $request = new Request([ 'name' => 'like:Region' ]);
         $locationController = new LocationController(new Location());
@@ -207,9 +207,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_not_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Region' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Region' ]);
-        factory(Location::class)->create([ 'name' => 'Esthar' ]);
+        Location::factory()->create([ 'name' => 'Balamb Region' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Region' ]);
+        Location::factory()->create([ 'name' => 'Esthar' ]);
 
         $request = new Request([ 'name' => 'not:Galbadia Region' ]);
         $locationController = new LocationController(new Location());
@@ -223,9 +223,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_area_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $request = new Request([ 'area' => 'Alcauld Plains' ]);
         $locationController = new LocationController(new Location());
@@ -238,9 +238,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_area_column_can_be_filtered_by_the_like_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $request = new Request([ 'area' => 'like:Plains' ]);
         $locationController = new LocationController(new Location());
@@ -254,9 +254,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_area_column_can_be_filtered_by_the_not_operator()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Timber', 'area' => 'Lanker Plains' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $request = new Request([ 'area' => 'not:Alcauld Plains' ]);
         $locationController = new LocationController(new Location());
@@ -270,9 +270,9 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function the_name_and_area_columns_can_both_be_filtered_together()
     {
-        factory(Location::class)->create([ 'name' => 'Balamb Garden', 'area' => 'Alcauld Plains' ]);
-        factory(Location::class)->create([ 'name' => 'Galbadia Garden', 'area' => 'Monterosa Plateau' ]);
-        factory(Location::class)->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
+        Location::factory()->create([ 'name' => 'Balamb Garden', 'area' => 'Alcauld Plains' ]);
+        Location::factory()->create([ 'name' => 'Galbadia Garden', 'area' => 'Monterosa Plateau' ]);
+        Location::factory()->create([ 'name' => 'Winhill', 'area' => 'Winhill Bluffs' ]);
 
         $request = new Request([
             'name' => 'like:Garden',
@@ -288,12 +288,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_region_without_additional_filters()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -318,12 +318,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_entire_region_relation()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -342,12 +342,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_name_column_on_the_region_relation()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',
@@ -373,12 +373,12 @@ class LocationControllerTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_columns_explicitly()
     {
-        $balambRegion = factory(Location::class)->create([
+        $balambRegion = Location::factory()->create([
             'name' => 'Balamb Region',
             'description' => 'This is technically the parent',
             'area' => 'Alcauld Plains',
         ]);
-        $balambGarden = factory(Location::class)->create([
+        $balambGarden = Location::factory()->create([
             'name' => 'Balamb Garden',
             'region_id' => $balambRegion->id,
             'description' => 'This is technically the child',

--- a/tests/Unit/Controllers/SeedRankControllerTest.php
+++ b/tests/Unit/Controllers/SeedRankControllerTest.php
@@ -17,7 +17,7 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function it_returns_a_list_of_seed_ranks()
     {
-        $seedRanks = factory(SeedRank::class, 10)->create();
+        $seedRanks = SeedRank::factory()->count(10)->create();
 
         $seedRankController = new SeedRankController(new SeedRank);
 
@@ -31,7 +31,7 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function it_returns_an_individual_seed_rank()
     {
-        $seedRank = factory(SeedRank::class)->create();
+        $seedRank = SeedRank::factory()->create();
 
         $seedRankController = new SeedRankController(new SeedRank);
 
@@ -49,7 +49,7 @@ class SeedRankControllerTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $seedRank = factory(SeedRank::class)->create();
+        $seedRank = SeedRank::factory()->create();
 
         $seedRankController = new SeedRankController(new SeedRank());
 
@@ -59,9 +59,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 5 ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -74,9 +74,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_gt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 'gt:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -89,9 +89,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_gte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 'gte:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -105,9 +105,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_lt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 'lt:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -120,9 +120,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_lte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 'lte:5' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -136,9 +136,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_like_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 'like:1' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -152,9 +152,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_rank_column_can_be_filtered_by_the_not_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10 ]);
+        SeedRank::factory()->create([ 'rank' => 1 ]);
+        SeedRank::factory()->create([ 'rank' => 5 ]);
+        SeedRank::factory()->create([ 'rank' => 10 ]);
 
         $request = new Request([ 'rank' => 'not:10' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -168,9 +168,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 500 ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -183,9 +183,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_gt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 'gt:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -198,9 +198,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_gte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 'gte:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -214,9 +214,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_lt_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 'lt:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -229,9 +229,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_lte_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 'lte:3000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -245,9 +245,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_like_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 'like:000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -261,9 +261,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_salary_column_can_be_filtered_by_the_not_operator()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([ 'salary' => 'not:8000' ]);
         $seedRankController = new SeedRankController(new SeedRank);
@@ -277,9 +277,9 @@ class SeedRankControllerTest extends TestCase
     /** @test */
     public function the_name_and_salary_columns_can_both_be_filtered_together()
     {
-        factory(SeedRank::class)->create([ 'rank' => 1, 'salary' => 500 ]);
-        factory(SeedRank::class)->create([ 'rank' => 5, 'salary' =>  3000 ]);
-        factory(SeedRank::class)->create([ 'rank' => 10, 'salary' => 8000 ]);
+        SeedRank::factory()->create([ 'rank' => 1, 'salary' => 500 ]);
+        SeedRank::factory()->create([ 'rank' => 5, 'salary' =>  3000 ]);
+        SeedRank::factory()->create([ 'rank' => 10, 'salary' => 8000 ]);
 
         $request = new Request([
             'rank' => 'like:1',

--- a/tests/Unit/Controllers/SeedTestControllerTest.php
+++ b/tests/Unit/Controllers/SeedTestControllerTest.php
@@ -18,7 +18,7 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_seed_tests()
     {
-        $seedTests = factory(SeedTest::class, 10)->create();
+        $seedTests = SeedTest::factory()->count(10)->create();
 
         $seedTestController = new SeedTestController(new SeedTest());
 
@@ -32,7 +32,7 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_returns_an_individual_seed_test()
     {
-        $seedTest = factory(SeedTest::class)->create();
+        $seedTest = SeedTest::factory()->create();
 
         $seedTestController = new SeedTestController(new SeedTest());
 
@@ -48,10 +48,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_relations_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -78,10 +78,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_relation_properties_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -112,10 +112,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_properties_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -149,7 +149,7 @@ class SeedTestControllerTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $seedTest = factory(SeedTest::class)->create();
+        $seedTest = SeedTest::factory()->create();
 
         $seedTestController = new SeedTestController(new SeedTest());
 
@@ -159,10 +159,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function the_level_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(SeedTest::class)->create([ 'level' => 1 ]);
-        factory(SeedTest::class)->create([ 'level' => 3 ]);
-        factory(SeedTest::class)->create([ 'level' => 10 ]);
-        factory(SeedTest::class)->create([ 'level' => 12 ]);
+        SeedTest::factory()->create([ 'level' => 1 ]);
+        SeedTest::factory()->create([ 'level' => 3 ]);
+        SeedTest::factory()->create([ 'level' => 10 ]);
+        SeedTest::factory()->create([ 'level' => 12 ]);
 
         $request = new Request([ 'level' => 1 ]);
         $seedTestController = new SeedTestController(new SeedTest());
@@ -175,10 +175,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function the_level_column_can_be_filtered_by_the_like_operator()
     {
-        factory(SeedTest::class)->create([ 'level' => 1 ]);
-        factory(SeedTest::class)->create([ 'level' => 3 ]);
-        factory(SeedTest::class)->create([ 'level' => 10 ]);
-        factory(SeedTest::class)->create([ 'level' => 12 ]);
+        SeedTest::factory()->create([ 'level' => 1 ]);
+        SeedTest::factory()->create([ 'level' => 3 ]);
+        SeedTest::factory()->create([ 'level' => 10 ]);
+        SeedTest::factory()->create([ 'level' => 12 ]);
 
         $request = new Request([ 'level' => 'like:1' ]);
         $seedTestController = new SeedTestController(new SeedTest());
@@ -193,10 +193,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function the_level_column_can_be_filtered_by_the_not_operator()
     {
-        factory(SeedTest::class)->create([ 'level' => 1 ]);
-        factory(SeedTest::class)->create([ 'level' => 3 ]);
-        factory(SeedTest::class)->create([ 'level' => 10 ]);
-        factory(SeedTest::class)->create([ 'level' => 12 ]);
+        SeedTest::factory()->create([ 'level' => 1 ]);
+        SeedTest::factory()->create([ 'level' => 3 ]);
+        SeedTest::factory()->create([ 'level' => 10 ]);
+        SeedTest::factory()->create([ 'level' => 12 ]);
 
         $request = new Request([ 'level' => 'not:10' ]);
         $seedTestController = new SeedTestController(new SeedTest());
@@ -211,10 +211,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_questions_without_additional_filters()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -239,10 +239,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_question_number_column_on_the_questions_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -271,10 +271,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_question_column_on_the_questions_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -303,10 +303,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_answer_column_on_the_questions_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -335,10 +335,10 @@ class SeedTestControllerTest extends TestCase
     /** @test */
     public function it_can_load_multiple_relation_columns_explicitly()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',

--- a/tests/Unit/Controllers/StatusEffectControllerTest.php
+++ b/tests/Unit/Controllers/StatusEffectControllerTest.php
@@ -17,7 +17,7 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_status_effects()
     {
-        $statusEffects = factory(StatusEffect::class, 10)->create();
+        $statusEffects = StatusEffect::factory()->count(10)->create();
 
         $statusEffectController = new StatusEffectController(new StatusEffect());
 
@@ -31,7 +31,7 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function it_returns_an_individual_status_effect()
     {
-        $statusEffect = factory(StatusEffect::class)->create();
+        $statusEffect = StatusEffect::factory()->create();
 
         $statusEffectController = new StatusEffectController(new StatusEffect());
 
@@ -49,7 +49,7 @@ class StatusEffectControllerTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $statusEffect = factory(StatusEffect::class)->create();
+        $statusEffect = StatusEffect::factory()->create();
 
         $statusEffectController = new StatusEffectController(new StatusEffect());
 
@@ -59,9 +59,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_filters_are_case_insensitive()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'name' => 'death' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -74,9 +74,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'name' => 'Triple' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -89,9 +89,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_like_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'name' => 'like:le' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -105,9 +105,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_name_column_can_be_filtered_by_the_not_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'name' => 'not:Triple' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -121,9 +121,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_type_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'type' => 'harmful' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -136,9 +136,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_type_column_can_be_filtered_by_the_like_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'type' => 'like:cial' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -153,9 +153,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_type_column_can_be_filtered_by_the_not_operator()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([ 'type' => 'not:beneficial' ]);
         $statusEffectController = new StatusEffectController(new StatusEffect());
@@ -169,9 +169,9 @@ class StatusEffectControllerTest extends TestCase
     /** @test */
     public function the_name_and_type_columns_can_both_be_filtered_together()
     {
-        factory(StatusEffect::class)->create([ 'name' => 'Death', 'type' => 'harmful' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
-        factory(StatusEffect::class)->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Death', 'type' => 'harmful' ]);
+        StatusEffect::factory()->create([ 'name' => 'Double', 'type' => 'beneficial' ]);
+        StatusEffect::factory()->create([ 'name' => 'Triple', 'type' => 'beneficial' ]);
 
         $request = new Request([
             'name' => 'like:Dou',

--- a/tests/Unit/Controllers/TestQuestionControllerTest.php
+++ b/tests/Unit/Controllers/TestQuestionControllerTest.php
@@ -18,7 +18,7 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function it_can_return_a_list_of_test_questions()
     {
-        $testQuestions = factory(TestQuestion::class, 10)->create();
+        $testQuestions = TestQuestion::factory()->count(10)->create();
 
         $testQuestionController = new TestQuestionController(new TestQuestion());
 
@@ -32,7 +32,7 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function it_returns_an_individual_test_question()
     {
-        $testQuestion = factory(TestQuestion::class)->create();
+        $testQuestion = TestQuestion::factory()->create();
 
         $testQuestionController = new TestQuestionController(new TestQuestion());
 
@@ -48,10 +48,10 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function it_can_load_relations_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -77,10 +77,10 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function it_can_load_relation_properties_on_individual_records()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -109,7 +109,7 @@ class TestQuestionControllerTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $testQuestion = factory(TestQuestion::class)->create();
+        $testQuestion = TestQuestion::factory()->create();
 
         $testQuestionController = new TestQuestionController(new TestQuestion());
 
@@ -119,17 +119,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_filters_are_case_insensitive()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What is the airspeed velocity of an Unladen Swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -147,17 +147,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -174,17 +174,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_lt_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -201,17 +201,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_lte_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -229,17 +229,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_gt_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -256,17 +256,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_gte_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -284,17 +284,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_like_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -311,17 +311,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_number_column_can_be_filtered_by_the_not_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -339,17 +339,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -366,17 +366,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_column_can_be_filtered_by_the_like_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -394,17 +394,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_question_column_can_be_filtered_by_the_not_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -422,17 +422,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_answer_column_can_be_filtered_by_the_equals_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -450,17 +450,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_answer_column_can_be_filtered_by_the_like_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -478,17 +478,17 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function the_answer_column_can_be_filtered_by_the_not_operator()
     {
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 1,
             'question' => 'What is your favorite color?',
             'answer' => 'yes',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 2,
             'question' => 'What Is the airspeed velocity of an unladen swallow?',
             'answer' => 'no',
         ]);
-        factory(TestQuestion::class)->create([
+        TestQuestion::factory()->create([
             'question_number' => 3,
             'question' => 'What is your quest?',
             'answer' => 'yes',
@@ -505,10 +505,10 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_test_without_additional_filters()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',
@@ -534,10 +534,10 @@ class TestQuestionControllerTest extends TestCase
     /** @test */
     public function it_can_load_the_level_column_on_the_test_relation()
     {
-        $seedTest = factory(SeedTest::class)->create([
+        $seedTest = SeedTest::factory()->create([
             'level' => 1,
         ]);
-        $testQuestion = factory(TestQuestion::class)->create([
+        $testQuestion = TestQuestion::factory()->create([
             'seed_test_id' => $seedTest->id,
             'question_number' => 1,
             'question' => 'Will this work?',


### PR DESCRIPTION
This upgrades Laravel to version 8. This upgrade comes with a major refactor to how Model Factories are handled, as well as a minor refactor to Seeders so that they are namespaced. PHPUnit was upgraded from version 8.5 to version 9. The PHPUnit upgrade comes with some deprecations that can be highlighted in its associated documentation. All Factories, Seeders, and Tests have been updated to encompass the upgrade to Laravel version 8.