### PR TITLE
ci: integrate GitHub Actions as CI platform (API-1)

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -1,0 +1,46 @@
+name: Build Branch
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  run-unit-tests:
+    if: "!contains(github.event.head_commit.message, '[automated release]')"
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    container: defrostedtuna/php-nginx:8.0
+    steps: 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: composer install --no-interaction
+
+      - name: Run Unit Tests
+        run: |
+          php artisan key:generate --env=testing
+          vendor/bin/phpunit
+
+  # We only want to build the branch if the commit was not pushed as part of an automated release.
+  # In the event the commit was pushed as part of the automated release, it would have already
+  # been built as a tag, in which case a container will already exist for the release.
+  build-image:
+    if: "!contains(github.event.head_commit.message, '[automated release]')"
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: run-unit-tests
+    steps: 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Authenticate with Docker Registry
+        run: echo ${{ secrets.DCR_PASSWORD }} | docker login ${{ secrets.DCR_SERVER }} -u ${{ secrets.DCR_USERNAME }} --password-stdin
+
+      - name: Build Container
+        run: docker build -t ${{ secrets.DCR_SERVER }}/${{ secrets.DCR_IMAGE_NAME }}:$(echo $GITHUB_REF | awk -F "/" '{print $3}')-$(echo $GITHUB_SHA | cut -c -7) .
+
+      - name: Push Container
+        run: docker push ${{ secrets.DCR_SERVER }}/${{ secrets.DCR_IMAGE_NAME }}:$(echo $GITHUB_REF | awk -F "/" '{print $3}')-$(echo $GITHUB_SHA | cut -c -7)

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,41 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - '*'
+  
+jobs:
+  run-unit-tests:
+    if: "!contains(github.event.head_commit.message, '[automated release]')"
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    container: defrostedtuna/php-nginx:8.0
+    steps: 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: composer install --no-interaction
+
+      - name: Run Unit Tests
+        run: |
+          php artisan key:generate --env=testing
+          vendor/bin/phpunit
+
+  build-image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: run-unit-tests
+    steps: 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Authenticate with Docker Registry
+        run: echo ${{ secrets.DCR_PASSWORD }} | docker login ${{ secrets.DCR_SERVER }} -u ${{ secrets.DCR_USERNAME }} --password-stdin
+
+      - name: Build Container
+        run: docker build -t ${{ secrets.DCR_SERVER }}/${{ secrets.DCR_IMAGE_NAME }}:$(echo $GITHUB_REF | awk -F "/" '{print $3}') .
+
+      - name: Push Container
+        run: docker push ${{ secrets.DCR_SERVER }}/${{ secrets.DCR_IMAGE_NAME }}:$(echo $GITHUB_REF | awk -F "/" '{print $3}')

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,96 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  run-unit-tests:
+    if: "!contains(github.event.head_commit.message, '[automated release]')"
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    container: defrostedtuna/php-nginx:8.0
+    steps: 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: composer install --no-interaction
+
+      - name: Run Unit Tests
+        run: |
+          php artisan key:generate --env=testing
+          vendor/bin/phpunit
+
+  # We want to release every commit that is pushed to master, with the exception of commits that are created
+  # as part of a changelog update. Changelog updates do not need to be built. There are two reasons for this.
+  # First is that when the code is merged to master, the release has not yet been created. It doesn't make a
+  # lot of sense to build the changelog into the master container when the release has not yet been created.
+  # Second is that when the release is created, it will contain the changes created by the actual release.
+  # While we could use the [skip ci] flag to ignore a changelog commit that is pushed back to master, this
+  # would also inadvertently allow the release build process to be skipped as well since they share commits.
+  # Instead, standard-version can be configured to apply the [automated release] flag, which we will ignore.
+  create-release:
+    if: "!contains(github.event.head_commit.message, '[automated release]')"
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: run-unit-tests
+    container:
+      image: node:15-alpine3.12
+    steps:
+      # Dependencies need to be installed before checking out the code
+      # so that the .git folder is cloned along with the repository.
+      # Installing gnu grep because I'm tired of dealing with busybox grep patterns.
+      - name: Install Dependencies
+        run: |
+          apk add --no-cache git openssh grep
+          yarn global add standard-version
+          git config --global user.name "tunabot"
+          git config --global user.email rbennett1106@gmail.com
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0 # This will allow the fetching of tags from the history for versioning.
+
+      # Using `git log --pretty="%B" -1` will get us the head commit of the branch so that we can read the message.
+      - name: Check For Version Override
+        id: version_override
+        run: |
+          export VERSION_OVERRIDE=$(echo $(git log --pretty="%B" -1) | grep -Poi "\[release.as.+\]")
+          export VERSION=$(echo $VERSION_OVERRIDE | grep -Poi "(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
+          if [ ! -z "$VERSION" ]; then
+            echo "Version set to $VERSION"
+            echo "::set-output name=version::$(echo "--release-as $VERSION")"
+          fi
+
+      - name: Create Changelog & Tag
+        id: prepare_release
+        run: |
+          git config user.name "tunabot"
+          git config user.email rbennett1106@gmail.com
+          standard-version -t "" $VERSION
+          git push --follow-tags
+          echo "Created Tag: $(git rev-parse HEAD | git tag --points-at)"
+          echo "::set-output name=commit::$(echo $(git rev-parse HEAD))"
+          echo "::set-output name=tag::$(echo $(git rev-parse HEAD | git tag --points-at))"
+        env:
+          VERSION: ${{ steps.version_override.outputs.version }}
+
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ steps.prepare_release.outputs.tag }}
+          path: ./CHANGELOG.md
+
+      - name: Publish Release
+        uses: ncipollo/release-action@v1.8.6
+        with:
+          name: v${{ steps.prepare_release.outputs.tag }}
+          commit: ${{ steps.prepare_release.outputs.commit }}
+          tag: ${{ steps.prepare_release.outputs.tag }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,21 @@
+name: Pull Request
+
+on:
+  pull_request:
+
+jobs:
+  run-unit-tests:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    container: defrostedtuna/php-nginx:8.0
+    steps: 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: composer install --no-interaction
+
+      - name: Run Unit Tests
+        run: |
+          php artisan key:generate --env=testing
+          vendor/bin/phpunit

--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "postchangelog": "sed -E 's/(#{1,3}) ([v]|[0-9]|[\\[])/## \\2/gi' -i CHANGELOG.md"
+  },
+  "releaseCommitMessageFormat": "chore(release): {{currentTag}} [automated release]",
+  "types": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix", "section": "Bug Fixes", "hidden": false },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "chore", "section": "Chore", "hidden": true }
+  ]
+}


### PR DESCRIPTION
Four workflows have been introduced here;

* build-branch
* build-release
* create-release
* pull-request

The build-branch and build-release workflows will simply run the application's unit tests, and then build the docker container in the event the test suite has successfully passed. While these two workflows ultimately accomplish the same task, they are different in the aspect that building a branch will use the first 7 characters of the commit hash as the Docker tag, while the release will use the git tag version as the Docker tag. The build-branch workflow will also have the Docker tag prefixed with the branch name. For example, a branch's docker container would be named something along the lines of `viiidb-api:develop-2d70624`, while a release's Docker container would be named something like `viiidb-api:1.0.0`.

The only reason for splitting these two workflows is to keep things a bit more self-contained. If these workflows are grouped together, conditionals would need to be put in place to manage which workflow runs on which git ref. Having conditionals in workflows should be kept to a minimum as whenever they are "skipped" they appear as a "passing" test on the CI flag next to the commit. This type of functionality is undesirable.

In addition to the two workflows mentioned above, there is also a workflow for create-release, as well as pull-request. Touching on pull-request first, this workflow will simply run unit tests whenever a pull request is opened. Nothing special or fancy there. The create-release workflow, however, will take care of issuing an official release when a pull request is merged into the `master` branch. Creating this release will invoke the standard-version NPM package to automate the process of versioning, as well as changelog generation. Upon successfully completing this, standard-version will commit the changes back to the `master` branch and proceed to create a git tag with the current version of the application. This tag will also be pushed to source control where it will be picked up by the Publish Release workflow job, linking the newly created tag to an official release.

It is important to note that the version that is released may be overridden by passing the `[release as]` flag to either the commit title, or body. For example, if it was desirable to create a release for `v0.1.0` the flag `[release as 0.1.0]` would need to be included in the commit (notice the omission of the `v` character).

To support the automated release cycle using standard-version, a `.versionrc` file has been included which store the configuration for standard-version. Within this configuration there is a `sed` script that will run once the changelog has been generated to standardize the changelog headings so they may be picked up by the release job properly.