### PR TITLE
refactor: update route parameter name for seed ranks (API-70)

### DIFF
--- a/routes/v0.php
+++ b/routes/v0.php
@@ -5,4 +5,4 @@ use App\Http\Controllers\V0\SeedRankController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/')->uses([HealthCheckController::class, 'status']);
-Route::resource('seed-ranks', SeedRankController::class)->only(['index', 'show']);
+Route::resource('seed-ranks', SeedRankController::class)->only(['index', 'show'])->parameters(['seed-ranks' => 'rank']);


### PR DESCRIPTION
This simply updates the route parameter name for the `/seed-ranks` endpoints from `seed_rank` to `rank`.