### PR TITLE
feat: add resources outline to status endpoint (API-68)

### DIFF
--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -13,10 +13,18 @@ class HealthCheckController extends Controller
     /**
      * Check the server's status.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function status(): JsonResponse
     {
-        return $this->respondWithSuccess('OK');
+        $baseUrl = config('app.url');
+        $currentApiVersion = config('app.current_api_version');
+
+        return $this->respondWithSuccess('VIIIDB API is running.', [
+            'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
+            'resources' => [
+                'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+            ],
+        ]);
     }
 }

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -9,14 +9,22 @@ class HealthCheckEndpointTest extends TestCase
     /** @test */
     public function it_can_check_the_server_status()
     {
+        $baseUrl = config('app.url');
+        $currentApiVersion = config('app.current_api_version');
+
         $response = $this->get('/v0');
 
         $response->assertStatus(200);
         $response->assertJson([
             'success' => true,
-            'message' => 'OK',
+            'message' => 'VIIIDB API is running.',
             'status_code' => 200,
-            'data' => null,
+            'data' => [
+                'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
+                'resources' => [
+                    'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+                ],
+            ],
         ]);
     }
 }

--- a/tests/Unit/Controllers/V0/HealthCheckControllerTest.php
+++ b/tests/Unit/Controllers/V0/HealthCheckControllerTest.php
@@ -10,15 +10,23 @@ class HealthCheckControllerTest extends TestCase
     /** @test */
     public function it_can_check_the_server_status()
     {
+        $baseUrl = config('app.url');
+        $currentApiVersion = config('app.current_api_version');
+
         $controller = new HealthCheckController();
         $response = $controller->status();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertArraySubset([
             'success' => true,
-            'message' => 'OK',
+            'message' => 'VIIIDB API is running.',
             'status_code' => 200,
-            'data' => null,
+            'data' => [
+                'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
+                'resources' => [
+                    'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+                ],
+            ],
         ], $response->getData(true));
     }
 }


### PR DESCRIPTION
Refactors the status endpoint response to include the resources that are currently live and available for consumption.