### PR TITLE
fix: allow release containers to be built (API-71)

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -7,7 +7,6 @@ on:
   
 jobs:
   run-unit-tests:
-    if: "!contains(github.event.head_commit.message, '[automated release]')"
     name: Run Unit Tests
     runs-on: ubuntu-latest
     container: defrostedtuna/php-nginx:8.0-dev


### PR DESCRIPTION
The Build Release workflow was set to ignore anything flagged with an `[automated release]` flag. This should not be the case as all releases should have their containers built.