### PR TITLE
refactor: explicitly define api routes (API-73)

### DIFF
--- a/routes/v0.php
+++ b/routes/v0.php
@@ -5,4 +5,5 @@ use App\Http\Controllers\V0\SeedRankController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/')->uses([HealthCheckController::class, 'status']);
-Route::resource('seed-ranks', SeedRankController::class)->only(['index', 'show'])->parameters(['seed-ranks' => 'rank']);
+Route::get('/seed-ranks/')->uses([SeedRankController::class, 'index']);
+Route::get('/seed-ranks/{rank}')->uses([SeedRankController::class, 'show']);


### PR DESCRIPTION
Instead of using resource routes and only plucking the ones needed, routes are now specified explicitly. Doing so allows route names to be excluded without the need to strip them from each individual endpoint in a resource route. Excluding the route names will alow the application to serialize the routes when the container is created. It also doesn't make much sense to use a resource route if only two of the endpoints in a resource route are needed.