### PR TITLE
feat: allow records to be filtered by the value of a given field (API-67)

### DIFF
--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\FiltersRecordsByFields;
 use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
 use App\Traits\Uuids;
@@ -10,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class SeedRank extends Model
 {
+    use FiltersRecordsByFields;
     use HasFactory;
     use OrdersQueryResults;
     use Searchable;
@@ -103,6 +105,16 @@ class SeedRank extends Model
      * @var array
      */
     protected $searchableFields = [
+        'rank',
+        'salary',
+    ];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
+    protected $filterableFields = [
         'rank',
         'salary',
     ];

--- a/app/Services/SeedRankService.php
+++ b/app/Services/SeedRankService.php
@@ -41,10 +41,13 @@ class SeedRankService implements SeedRankServiceContract
             $query->search($request->search);
         }
 
-        return $query->orderBy(
-            $this->model->getOrderByField(),
-            $this->model->getOrderByDirection()
-        )->get()->toArray();
+        return $query->filter($request->query())
+            ->orderBy(
+                $this->model->getOrderByField(),
+                $this->model->getOrderByDirection()
+            )
+            ->get()
+            ->toArray();
     }
 
     /**

--- a/app/Traits/FiltersRecordsByFields.php
+++ b/app/Traits/FiltersRecordsByFields.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait FiltersRecordsByFields
+{
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
+    public function getFilterableFields(): array
+    {
+        return isset($this->filterableFields) ? $this->filterableFields : [];
+    }
+
+    /**
+     * Filter the records by the given criteria.
+     *
+     * @param Builder $query   The Eloquent Query Builder instance
+     * @param array   $filters An array of `key => value` pairs that correspond to `field => filter`
+     *
+     * @return Builder
+     */
+    public function scopeFilter(Builder $query, array $filters): Builder
+    {
+        $filters = array_intersect_key(
+            $filters,
+            array_flip($this->getFilterableFields())
+        );
+
+        foreach ($filters as $key => $value) {
+            $pieces = explode(':', $value);
+            $hasLikeOperator = strtolower($pieces[0]) === 'like';
+
+            if ($hasLikeOperator) {
+                $impl = implode(':', array_slice($pieces, 1));
+                $value = "%{$impl}%";
+            }
+
+            $query->where(
+                $key,
+                $hasLikeOperator ? 'LIKE' : '=',
+                $value
+            );
+        }
+
+        return $query;
+    }
+}

--- a/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
@@ -140,4 +140,116 @@ class SeedRankEndpointTest extends TestCase
             ],
         ]);
     }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_rank_column()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $response = $this->get('/v0/seed-ranks?rank=1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $response = $this->get('/v0/seed-ranks?rank=like:1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+                [
+                    'id' => $three->id,
+                    'rank' => $three->rank,
+                    'salary' => $three->salary,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_salary_column()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $response = $this->get('/v0/seed-ranks?salary=500');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000]);
+
+        $response = $this->get('/v0/seed-ranks?salary=like:500');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+                [
+                    'id' => $two->id,
+                    'rank' => $two->rank,
+                    'salary' => $two->salary,
+                ],
+                [
+                    'id' => $four->id,
+                    'rank' => $four->rank,
+                    'salary' => $four->salary,
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Unit/Controllers/V0/SeedRankControllerTest.php
+++ b/tests/Unit/Controllers/V0/SeedRankControllerTest.php
@@ -150,4 +150,128 @@ class SeedRankControllerTest extends TestCase
             ],
         ], $response->getData(true));
     }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_rank_column()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $service = $this->app->make(SeedRankService::class);
+        $transformer = new SeedRankTransformer();
+        $controller = new SeedRankController($service, $transformer);
+
+        $response = $controller->index(new Request(['rank' => 1]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $service = $this->app->make(SeedRankService::class);
+        $transformer = new SeedRankTransformer();
+        $controller = new SeedRankController($service, $transformer);
+
+        $response = $controller->index(new Request(['rank' => 'like:1']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+                [
+                    'id' => $three->id,
+                    'rank' => $three->rank,
+                    'salary' => $three->salary,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_salary_column()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $service = $this->app->make(SeedRankService::class);
+        $transformer = new SeedRankTransformer();
+        $controller = new SeedRankController($service, $transformer);
+
+        $response = $controller->index(new Request(['salary' => 500]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000]);
+
+        $service = $this->app->make(SeedRankService::class);
+        $transformer = new SeedRankTransformer();
+        $controller = new SeedRankController($service, $transformer);
+
+        $response = $controller->index(new Request(['salary' => 'like:500']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'rank' => $one->rank,
+                    'salary' => $one->salary,
+                ],
+                [
+                    'id' => $two->id,
+                    'rank' => $two->rank,
+                    'salary' => $two->salary,
+                ],
+                [
+                    'id' => $four->id,
+                    'rank' => $four->rank,
+                    'salary' => $four->salary,
+                ],
+            ],
+        ], $response->getData(true));
+    }
 }

--- a/tests/Unit/Models/SeedRankTest.php
+++ b/tests/Unit/Models/SeedRankTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Models;
 
 use App\Models\SeedRank;
+use App\Traits\FiltersRecordsByFields;
 use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
 use App\Traits\Uuids;
@@ -126,6 +127,19 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
+    public function it_explicitly_defines_the_fields_that_are_filterable()
+    {
+        $seedRank = new SeedRank();
+
+        $expected = [
+            'rank',
+            'salary',
+        ];
+
+        $this->assertEquals($expected, $seedRank->getFilterableFields());
+    }
+
+    /** @test */
     public function it_explicitly_defines_the_route_key_name()
     {
         $seedRank = new SeedRank();
@@ -167,6 +181,15 @@ class SeedRankTest extends TestCase
     {
         $this->assertTrue(in_array(
             Searchable::class,
+            class_uses(SeedRank::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_the_ability_to_filter_records_by_fields()
+    {
+        $this->assertTrue(in_array(
+            FiltersRecordsByFields::class,
             class_uses(SeedRank::class)
         ));
     }

--- a/tests/Unit/Services/SeedRankServiceTest.php
+++ b/tests/Unit/Services/SeedRankServiceTest.php
@@ -113,4 +113,104 @@ class SeedRankServiceTest extends TestCase
             ],
         ], $records);
     }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_rank_column()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $model = new SeedRank();
+        $service = new SeedRankService($model);
+
+        $records = $service->all(new Request(['rank' => 1]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'rank' => $one->rank,
+                'salary' => $one->salary,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $model = new SeedRank();
+        $service = new SeedRankService($model);
+
+        $records = $service->all(new Request(['rank' => 'like:1']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'rank' => $one->rank,
+                'salary' => $one->salary,
+            ],
+            [
+                'id' => $three->id,
+                'rank' => $three->rank,
+                'salary' => $three->salary,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_salary_column()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+
+        $model = new SeedRank();
+        $service = new SeedRankService($model);
+
+        $records = $service->all(new Request(['salary' => 500]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'rank' => $one->rank,
+                'salary' => $one->salary,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement()
+    {
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000]);
+
+        $model = new SeedRank();
+        $service = new SeedRankService($model);
+
+        $records = $service->all(new Request(['salary' => 'like:500']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'rank' => $one->rank,
+                'salary' => $one->salary,
+            ],
+            [
+                'id' => $two->id,
+                'rank' => $two->rank,
+                'salary' => $two->salary,
+            ],
+            [
+                'id' => $four->id,
+                'rank' => $four->rank,
+                'salary' => $four->salary,
+            ],
+        ], $records);
+    }
 }


### PR DESCRIPTION
A new trait has been added that will allow models to filter records based on the values of the fields that have been marked as "filterable". Users may pass a `key=value` pair to the query string representing the data they would like to retrieve from the API. For example; https://api.viiidb.com/v0/seed-ranks?rank=1 will return all of the SeeD Ranks where the `rank` column is equal to `1`. Likewise, https://api.viiidb.com/v0/seed-ranks?salary=500 will return all of the SeeD Ranks where the `salary` column is equal to `500`.

In the event a user does not know the exact value of the record they would like to retrieve, the `like:` prefix may be included as part of the `value` in order to return all records that are similar to the value specified. For example; https://api.viiidb.com/v0/seed-ranks?rank=like:1 will return all of the SeeD Ranks where the `rank` column is similar to `1` (1, 10, 12, 21, etc...). Likewise, https://api.viiidb.com/v0/seed-ranks?salary=like:500 will return all of the SeeD Ranks where the `salary` column is similar to `500` (500, 1500, 2500, 15000, etc...).

This can be set up by simply including the `App\Traits\FiltersRecordsByFields` trait on the model and instructing it to use said trait. From there, an array of fields should be defined via the `filterableFields` property on the model. The associated service will be responsible for filtering these records for the end user.