### PR TITLE
feat: add seed test resource (API-10)

### DIFF
--- a/app/Contracts/Services/SeedTestService.php
+++ b/app/Contracts/Services/SeedTestService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Contracts\Services;
+
+use Illuminate\Http\Request;
+
+interface SeedTestService
+{
+    /**
+     * Retrieve all of the records in the database.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return array
+     */
+    public function all(Request $request): array;
+
+    /**
+     * Retrieve a specific record from the database, or fail if a record was not found.
+     *
+     * @param string  $seedTestId The ID of the requested SeedTest
+     * @param Request $request    The HTTP request from the client
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+     *
+     * @return array
+     */
+    public function findOrFail(string $seedTestId, Request $request): array;
+}

--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -24,6 +24,7 @@ class HealthCheckController extends Controller
             'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
             'resources' => [
                 'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+                'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
             ],
         ]);
     }

--- a/app/Http/Controllers/V0/SeedTestController.php
+++ b/app/Http/Controllers/V0/SeedTestController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\SeedTestService;
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\V0\SeedTestTransformer;
+use App\Traits\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SeedTestController extends Controller
+{
+    use ApiResponse;
+
+    /**
+     * Instance of the SeedTestService.
+     *
+     * @var SeedTestService
+     */
+    protected $seedTestService;
+
+    /**
+     * Instance of the SeedTestTransformer.
+     *
+     * @var SeedTestTransformer
+     */
+    protected $seedTestTransformer;
+
+    /**
+     * Create a new SeedTestController instance.
+     *
+     * @param SeedTestService     $seedTestService     The Service that will process the request
+     * @param SeedTestTransformer $seedTestTransformer The Transformer that will standardize the response
+     */
+    public function __construct(SeedTestService $seedTestService, SeedTestTransformer $seedTestTransformer)
+    {
+        $this->seedTestService = $seedTestService;
+        $this->seedTestTransformer = $seedTestTransformer;
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $records = $this->seedTestService->all($request);
+
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->seedTestTransformer->transformCollection($records)
+        );
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param Request $request    The HTTP request from the client
+     * @param string  $seedTestId The ID of the requested SeedTest
+     *
+     * @return JsonResponse
+     */
+    public function show(Request $request, string $seedTestId): JsonResponse
+    {
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->seedTestTransformer->transformRecord(
+                $this->seedTestService->findOrFail($seedTestId, $request)
+            )
+        );
+    }
+}

--- a/app/Http/Transformers/V0/SeedTestTransformer.php
+++ b/app/Http/Transformers/V0/SeedTestTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Transformers\V0;
+
+use App\Contracts\Transformers\RecordTransformer;
+
+class SeedTestTransformer implements RecordTransformer
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array $record The record to be transformed
+     *
+     * @return array
+     */
+    public function transformRecord(array $record): array
+    {
+        return [
+            'id' => $record['id'],
+            'level' => $record['level'],
+        ];
+    }
+
+    /**
+     * Transforms a collection of records to standardize the output.
+     *
+     * @param array $collection The collection of records to be transformed
+     *
+     * @return array
+     */
+    public function transformCollection(array $collection): array
+    {
+        $data = [];
+
+        foreach ($collection as $record) {
+            $data[] = $this->transformRecord($record);
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\FiltersRecordsByFields;
+use App\Traits\OrdersQueryResults;
+use App\Traits\Searchable;
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SeedTest extends Model
+{
+    use FiltersRecordsByFields;
+    use HasFactory;
+    use OrdersQueryResults;
+    use Searchable;
+    use Uuids;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'seed_tests';
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The default field used to order query results by.
+     *
+     * @var array
+     */
+    protected $orderByField = 'level';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var array
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [];
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'level',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id'    => 'string',
+        'level' => 'int',
+    ];
+
+    /**
+     * The fields that should be searchable.
+     *
+     * @var array
+     */
+    protected $searchableFields = [
+        'level',
+    ];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
+    protected $filterableFields = [
+        'level',
+    ];
+
+    /*
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'level';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,6 +17,11 @@ class AppServiceProvider extends ServiceProvider
             \App\Contracts\Services\SeedRankService::class,
             \App\Services\SeedRankService::class
         );
+
+        $this->app->bind(
+            \App\Contracts\Services\SeedTestService::class,
+            \App\Services\SeedTestService::class
+        );
     }
 
     /**

--- a/app/Services/SeedTestService.php
+++ b/app/Services/SeedTestService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Services\SeedTestService as SeedTestServiceContract;
+use App\Models\SeedTest;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class SeedTestService implements SeedTestServiceContract
+{
+    /**
+     * The instance of the model to use for the service.
+     *
+     * @var SeedTest
+     */
+    protected $model;
+
+    /**
+     * Create a new SeedTestService instance.
+     *
+     * @param SeedTest $model The instance of the model to use for the service
+     */
+    public function __construct(SeedTest $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Retrieve all of the records in the database.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return array
+     */
+    public function all(Request $request): array
+    {
+        $query = $this->model->newModelQuery();
+
+        if ($request->has('search')) {
+            $query->search($request->search);
+        }
+
+        return $query->filter($request->query())
+            ->orderBy(
+                $this->model->getOrderByField(),
+                $this->model->getOrderByDirection()
+            )
+            ->get()
+            ->toArray();
+    }
+
+    /**
+     * Retrieve a specific record from the database, or fail if a record was not found.
+     *
+     * @param string  $seedTestId The ID of the requested SeedTest
+     * @param Request $request    The HTTP request from the client
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return array
+     */
+    public function findOrFail(string $seedTestId, Request $request): array
+    {
+        $data = $this->model
+            ->where($this->model->getKeyName(), $seedTestId)
+            ->orWhere($this->model->getRouteKeyName(), $seedTestId)
+            ->first();
+
+        if (! $data) {
+            throw new NotFoundHttpException('The requested record could not be found.');
+        }
+
+        return $data->toArray();
+    }
+}

--- a/database/factories/SeedTestFactory.php
+++ b/database/factories/SeedTestFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SeedTest;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SeedTestFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SeedTest::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'level' => $this->faker->numberBetween(0, 30),
+        ];
+    }
+}

--- a/database/migrations/2021_08_27_192521_create_seed_tests_table.php
+++ b/database/migrations/2021_08_27_192521_create_seed_tests_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSeedTestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('seed_tests', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->integer('level');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('seed_tests');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,5 +14,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(SeedRanksTableSeeder::class);
+        $this->call(SeedTestsTableSeeder::class);
     }
 }

--- a/database/seeders/SeedTestsTableSeeder.php
+++ b/database/seeders/SeedTestsTableSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\SeedTest;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class SeedTestsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $seedTests = [];
+
+        for ($i = 1; $i <= 30; $i++) {
+            $seedTests[] = [
+                'id' => Uuid::generate(4),
+                'level' => $i,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ];
+        }
+
+        $seedTest = new SeedTest();
+
+        $seedTest->insert($seedTests);
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -2,8 +2,13 @@
 
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\SeedRankController;
+use App\Http\Controllers\V0\SeedTestController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/')->uses([HealthCheckController::class, 'status']);
+
 Route::get('/seed-ranks/')->uses([SeedRankController::class, 'index']);
 Route::get('/seed-ranks/{rank}')->uses([SeedRankController::class, 'show']);
+
+Route::get('/seed-tests/')->uses([SeedTestController::class, 'index']);
+Route::get('/seed-tests/{test}')->uses([SeedTestController::class, 'show']);

--- a/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\SeedTest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeedTestEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_seed_tests()
+    {
+        $seedTests = SeedTest::factory()->count(10)->create();
+
+        $response = $this->get('/v0/seed-tests');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_seed_test_using_the_id_key()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $response = $this->get("/v0/seed-tests/{$seedTest->id}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $seedTest->id,
+                'level' => $seedTest->level,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_seed_test_using_the_level_key()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $response = $this->get("/v0/seed-tests/{$seedTest->level}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $seedTest->id,
+                'level' => $seedTest->level,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/v0/seed-tests/invalid');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_seed_tests_via_the_level_column()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $response = $this->get('/v0/seed-tests?search=1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'level' => $one->level,
+                ],
+                [
+                    'id' => $three->id,
+                    'level' => $three->level,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_tests_via_the_level_column()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        SeedTest::factory()->create(['level' => 10]);
+
+        $response = $this->get('/v0/seed-tests?level=1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'level' => $one->level,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $response = $this->get('/v0/seed-tests?level=like:1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'level' => $one->level,
+                ],
+                [
+                    'id' => $three->id,
+                    'level' => $three->level,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Controllers/V0/SeedTestControllerTest.php
+++ b/tests/Unit/Controllers/V0/SeedTestControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Unit\Controllers\V0;
+
+use App\Contracts\Services\SeedTestService;
+use App\Http\Controllers\V0\SeedTestController;
+use App\Http\Transformers\V0\SeedTestTransformer;
+use App\Models\SeedTest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class SeedTestControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_seed_tests()
+    {
+        $seedTests = SeedTest::factory()->count(10)->create();
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $response = $controller->index(new Request());
+
+        $this->assertArraySubset([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ], $response->getData(true));
+        $this->assertCount(10, $response->getData(true)['data']);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_seed_test_using_the_id_key()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $response = $controller->show(new Request(), $seedTest->id);
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $seedTest->id,
+                'level' => $seedTest->level,
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_seed_test_using_the_level_key()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $response = $controller->show(new Request(), $seedTest->level);
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $seedTest->id,
+                'level' => $seedTest->level,
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $controller->show(new Request(), 'not-found');
+    }
+
+    /** @test */
+    public function it_can_search_for_seed_tests_via_the_level_column()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $response = $controller->index(new Request(['search' => 1]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'level' => $one->level,
+                ],
+                [
+                    'id' => $three->id,
+                    'level' => $three->level,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_seed_tests_via_the_level_column()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $response = $controller->index(new Request(['level' => 1]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'level' => $one->level,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $service = $this->app->make(SeedTestService::class);
+        $transformer = new SeedTestTransformer();
+        $controller = new SeedTestController($service, $transformer);
+
+        $response = $controller->index(new Request(['level' => 'like:1']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'level' => $one->level,
+                ],
+                [
+                    'id' => $three->id,
+                    'level' => $three->level,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+}

--- a/tests/Unit/Models/SeedTestTest.php
+++ b/tests/Unit/Models/SeedTestTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\SeedTest;
+use App\Traits\FiltersRecordsByFields;
+use App\Traits\OrdersQueryResults;
+use App\Traits\Searchable;
+use App\Traits\Uuids;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase as TestCase;
+
+class SeedTestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_explicitly_disables_incrementing_primary_keys()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertFalse($seedTest->getIncrementing());
+    }
+
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals('seed_tests', $seedTest->getTable());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_column_explicitly()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals('id', $seedTest->getKeyName());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals('string', $seedTest->getKeyType());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals('level', $seedTest->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals('asc', $seedTest->getOrderByDirection());
+    }
+
+    /** @test */
+    public function it_does_not_allow_properties_to_be_assigned_in_mass()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals([], $seedTest->getFillable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $seedTest = new SeedTest();
+
+        $visibleFields = [
+            'id',
+            'level',
+        ];
+
+        $this->assertEquals($visibleFields, $seedTest->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    {
+        $seedTest = new SeedTest();
+
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        $this->assertEquals($hiddenFields, $seedTest->getHidden());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_cast_type_for_each_field()
+    {
+        $seedTest = new SeedTest();
+        $fields = $seedTest->getCasts();
+
+        $expected = [
+            'id' => 'string',
+            'level' => 'int',
+        ];
+
+        $this->assertEquals($expected, $fields);
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_searchable()
+    {
+        $seedTest = new SeedTest();
+
+        $expected = [
+            'level',
+        ];
+
+        $this->assertEquals($expected, $seedTest->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_filterable()
+    {
+        $seedTest = new SeedTest();
+
+        $expected = [
+            'level',
+        ];
+
+        $this->assertEquals($expected, $seedTest->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_route_key_name()
+    {
+        $seedTest = new SeedTest();
+
+        $this->assertEquals('level', $seedTest->getRouteKeyName());
+    }
+
+    /** @test */
+    public function it_uses_uuids_for_the_primary_key()
+    {
+        $this->assertTrue(in_array(
+            Uuids::class,
+            class_uses(SeedTest::class)
+        ));
+    }
+
+    /** @test */
+    public function it_will_not_allow_the_uuid_to_be_changed()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $seedTest->id = 'not-original-value';
+        $seedTest->save();
+
+        $this->assertFalse($seedTest->id === 'not-original-value');
+    }
+
+    /** @test */
+    public function it_can_order_query_results()
+    {
+        $this->assertTrue(in_array(
+            OrdersQueryResults::class,
+            class_uses(SeedTest::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_search_functionality()
+    {
+        $this->assertTrue(in_array(
+            Searchable::class,
+            class_uses(SeedTest::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_the_ability_to_filter_records_by_fields()
+    {
+        $this->assertTrue(in_array(
+            FiltersRecordsByFields::class,
+            class_uses(SeedTest::class)
+        ));
+    }
+}

--- a/tests/Unit/Services/SeedTestServiceTest.php
+++ b/tests/Unit/Services/SeedTestServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\SeedTest;
+use App\Services\SeedTestService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class SeedTestServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_seed_tests()
+    {
+        $seedTests = SeedTest::factory()->count(10)->create();
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $records = $service->all(new Request());
+
+        $sortedSeedTests = $seedTests->sortBy([
+            [$model->getOrderByField(), $model->getOrderByDirection()],
+        ]);
+
+        $this->assertEquals($sortedSeedTests->toArray(), $records);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_seed_test_using_the_id_key()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $records = $service->findOrFail($seedTest->id, new Request());
+
+        $this->assertEquals($seedTest->toArray(), $records);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_seed_test_using_the_level_key()
+    {
+        $seedTest = SeedTest::factory()->create();
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $records = $service->findOrFail($seedTest->level, new Request());
+
+        $this->assertEquals($seedTest->toArray(), $records);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $service->findOrFail('not-found', new Request());
+    }
+
+    /** @test */
+    public function it_can_search_for_seed_tests_via_the_level_column()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $records = $service->all(new Request(['search' => 1]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'level' => $one->level,
+            ],
+            [
+                'id' => $three->id,
+                'level' => $three->level,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_tests_via_the_level_column()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        SeedTest::factory()->create(['level' => 10]);
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $records = $service->all(new Request(['level' => 1]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'level' => $one->level,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement()
+    {
+        $one = SeedTest::factory()->create(['level' => 1]);
+        SeedTest::factory()->create(['level' => 5]);
+        $three = SeedTest::factory()->create(['level' => 10]);
+
+        $model = new SeedTest();
+        $service = new SeedTestService($model);
+
+        $records = $service->all(new Request(['level' => 'like:1']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'level' => $one->level,
+            ],
+            [
+                'id' => $three->id,
+                'level' => $three->level,
+            ],
+        ], $records);
+    }
+}

--- a/tests/Unit/Transformers/V0/SeedTestTransformerTest.php
+++ b/tests/Unit/Transformers/V0/SeedTestTransformerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\V0\SeedTestTransformer;
+use App\Models\SeedTest;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Tests\TestCase;
+
+class SeedTestTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_transform_a_single_record()
+    {
+        $seedTest = SeedTest::factory()->make([
+            'id' => 'some-random-uuid',
+            'level' => '1',
+            'arbitrary' => 'data',
+        ]);
+
+        $transformer = new SeedTestTransformer();
+
+        $transformedRecord = $transformer->transformRecord($seedTest->toArray());
+
+        $this->assertEquals([
+            'id' => $seedTest->id,
+            'level' => $seedTest->level,
+        ], $transformedRecord);
+    }
+
+    /** @test */
+    public function it_will_transform_a_collection_of_records()
+    {
+        $seedTests = SeedTest::factory()->count(3)->make(new Sequence(
+            ['id' => 'one'],
+            ['id' => 'two'],
+            ['id' => 'three']
+        ));
+
+        $transformer = new SeedTestTransformer();
+
+        $transformedRecords = $transformer->transformCollection($seedTests->toArray());
+
+        $this->assertEquals([
+            [
+                'id' => $seedTests[0]->id,
+                'level' => $seedTests[0]->level,
+            ],
+            [
+                'id' => $seedTests[1]->id,
+                'level' => $seedTests[1]->level,
+            ],
+            [
+                'id' => $seedTests[2]->id,
+                'level' => $seedTests[2]->level,
+            ],
+        ], $transformedRecords);
+    }
+}


### PR DESCRIPTION
The SeeD Test resource has been added!

This resource includes the same scaffolding and functionality as with the SeeD Rank resource, and is available via the `/seed-tests` endpoint. Note that this is only the SeeD Test resource itself, and does not include the associated Test Questions. The Test Questions would "technically" be considered their own resource and will be included as part of a different PR. When the Test Questions resource is added, they will also be tied to the SeeD Test resource as part of the same PR.