### PR TITLE
feat: add test questions resource & relationship scaffolding (API-9)

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -92,9 +92,7 @@ $rules = [
     'ordered_imports' => [
         'sort_algorithm' => 'alpha',
     ],
-    'php_unit_method_casing' => [
-        'case' => 'snake_case',
-    ],
+    'php_unit_method_casing' => false,
     'phpdoc_types_order' => [
         'null_adjustment' => 'always_last',
     ],

--- a/app/Contracts/Services/TestQuestionService.php
+++ b/app/Contracts/Services/TestQuestionService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Contracts\Services;
+
+use Illuminate\Http\Request;
+
+interface TestQuestionService
+{
+    /**
+     * Retrieve all of the records in the database.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return array
+     */
+    public function all(Request $request): array;
+
+    /**
+     * Retrieve a specific record from the database, or fail if a record was not found.
+     *
+     * @param string  $testQuestionId The ID of the requested TestQuestion
+     * @param Request $request        The HTTP request from the client
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+     *
+     * @return array
+     */
+    public function findOrFail(string $testQuestionId, Request $request): array;
+}

--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -25,6 +25,7 @@ class HealthCheckController extends Controller
             'resources' => [
                 'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
                 'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
+                'test_questions' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
             ],
         ]);
     }

--- a/app/Http/Controllers/V0/TestQuestionController.php
+++ b/app/Http/Controllers/V0/TestQuestionController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\TestQuestionService;
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\V0\TestQuestionTransformer;
+use App\Traits\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TestQuestionController extends Controller
+{
+    use ApiResponse;
+
+    /**
+     * Instance of the TestQuestionService.
+     *
+     * @var TestQuestionService
+     */
+    protected $testQuestionService;
+
+    /**
+     * Instance of the TestQuestionTransformer.
+     *
+     * @var TestQuestionTransformer
+     */
+    protected $testQuestionTransformer;
+
+    /**
+     * Create a new TestQuestionController instance.
+     *
+     * @param TestQuestionService     $testQuestionService     The Service that will process the request
+     * @param TestQuestionTransformer $testQuestionTransformer The Transformer that will standardize the response
+     */
+    public function __construct(TestQuestionService $testQuestionService, TestQuestionTransformer $testQuestionTransformer)
+    {
+        $this->testQuestionService = $testQuestionService;
+        $this->testQuestionTransformer = $testQuestionTransformer;
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $records = $this->testQuestionService->all($request);
+
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->testQuestionTransformer->transformCollection($records)
+        );
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param Request $request        The HTTP request from the client
+     * @param string  $testQuestionId The ID of the requested TestQuestion
+     *
+     * @return JsonResponse
+     */
+    public function show(Request $request, string $testQuestionId): JsonResponse
+    {
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->testQuestionTransformer->transformRecord(
+                $this->testQuestionService->findOrFail($testQuestionId, $request)
+            )
+        );
+    }
+}

--- a/app/Http/Transformers/V0/SeedTestTransformer.php
+++ b/app/Http/Transformers/V0/SeedTestTransformer.php
@@ -7,6 +7,13 @@ use App\Contracts\Transformers\RecordTransformer;
 class SeedTestTransformer implements RecordTransformer
 {
     /**
+     * Instance of the TestQuestionTransformer.
+     *
+     * @var TestQuestionTransformer
+     */
+    protected $testQuestionTransformer;
+
+    /**
      * Transforms an individual record to standardize the output.
      *
      * @param array $record The record to be transformed
@@ -15,10 +22,18 @@ class SeedTestTransformer implements RecordTransformer
      */
     public function transformRecord(array $record): array
     {
-        return [
+        $data = [
             'id' => $record['id'],
             'level' => $record['level'],
         ];
+
+        if (array_key_exists('test_questions', $record)) {
+            $data['test_questions'] = $record['test_questions']
+                ? $this->getTestQuestionTransformer()->transformCollection($record['test_questions'])
+                : null;
+        }
+
+        return $data;
     }
 
     /**
@@ -37,5 +52,21 @@ class SeedTestTransformer implements RecordTransformer
         }
 
         return $data;
+    }
+
+    /**
+     * Get the instance of the TestQuestionTransformer.
+     *
+     * If an existing instance does not exist, a new instance will be created.
+     *
+     * @return TestQuestionTransformer
+     */
+    protected function getTestQuestionTransformer(): TestQuestionTransformer
+    {
+        if (! $this->testQuestionTransformer) {
+            $this->testQuestionTransformer = new TestQuestionTransformer();
+        }
+
+        return $this->testQuestionTransformer;
     }
 }

--- a/app/Http/Transformers/V0/TestQuestionTransformer.php
+++ b/app/Http/Transformers/V0/TestQuestionTransformer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Transformers\V0;
+
+use App\Contracts\Transformers\RecordTransformer;
+
+class TestQuestionTransformer implements RecordTransformer
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array $record The record to be transformed
+     *
+     * @return array
+     */
+    public function transformRecord(array $record): array
+    {
+        return [
+            'id' => $record['id'],
+            'sort_id' => $record['sort_id'],
+            'seed_test_id' => $record['seed_test_id'],
+            'question_number' => $record['question_number'],
+            'question' => $record['question'],
+            'answer' => $record['answer'],
+        ];
+    }
+
+    /**
+     * Transforms a collection of records to standardize the output.
+     *
+     * @param array $collection The collection of records to be transformed
+     *
+     * @return array
+     */
+    public function transformCollection(array $collection): array
+    {
+        $data = [];
+
+        foreach ($collection as $record) {
+            $data[] = $this->transformRecord($record);
+        }
+
+        return $data;
+    }
+}

--- a/app/Http/Transformers/V0/TestQuestionTransformer.php
+++ b/app/Http/Transformers/V0/TestQuestionTransformer.php
@@ -7,6 +7,13 @@ use App\Contracts\Transformers\RecordTransformer;
 class TestQuestionTransformer implements RecordTransformer
 {
     /**
+     * Instance of the SeedTestTransformer.
+     *
+     * @var SeedTestTransformer
+     */
+    protected $seedTestTransformer;
+
+    /**
      * Transforms an individual record to standardize the output.
      *
      * @param array $record The record to be transformed
@@ -15,7 +22,7 @@ class TestQuestionTransformer implements RecordTransformer
      */
     public function transformRecord(array $record): array
     {
-        return [
+        $data = [
             'id' => $record['id'],
             'sort_id' => $record['sort_id'],
             'seed_test_id' => $record['seed_test_id'],
@@ -23,6 +30,14 @@ class TestQuestionTransformer implements RecordTransformer
             'question' => $record['question'],
             'answer' => $record['answer'],
         ];
+
+        if (array_key_exists('seed_test', $record)) {
+            $data['seed_test'] = $record['seed_test']
+                ? $this->getSeedTestTransformer()->transformRecord($record['seed_test'])
+                : null;
+        }
+
+        return $data;
     }
 
     /**
@@ -41,5 +56,21 @@ class TestQuestionTransformer implements RecordTransformer
         }
 
         return $data;
+    }
+
+    /**
+     * Get the instance of the SeedTestTransformer.
+     *
+     * If an existing instance does not exist, a new instance will be created.
+     *
+     * @return SeedTestTransformer
+     */
+    protected function getSeedTestTransformer(): SeedTestTransformer
+    {
+        if (! $this->seedTestTransformer) {
+            $this->seedTestTransformer = new SeedTestTransformer();
+        }
+
+        return $this->seedTestTransformer;
     }
 }

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -3,16 +3,19 @@
 namespace App\Models;
 
 use App\Traits\FiltersRecordsByFields;
+use App\Traits\LoadsRelationsThroughServices;
 use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SeedTest extends Model
 {
     use FiltersRecordsByFields;
     use HasFactory;
+    use LoadsRelationsThroughServices;
     use OrdersQueryResults;
     use Searchable;
     use Uuids;
@@ -74,6 +77,7 @@ class SeedTest extends Model
     protected $visible = [
         'id',
         'level',
+        'testQuestions',
     ];
 
     /**
@@ -115,6 +119,22 @@ class SeedTest extends Model
         'level',
     ];
 
+    /**
+     * The relations that are available to include with the resource.
+     *
+     * @var array
+     */
+    protected $availableIncludes = [
+        'testQuestions',
+    ];
+
+    /**
+     * The default relations to include with the resource.
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [];
+
     /*
      * Get the route key for the model.
      *
@@ -123,5 +143,15 @@ class SeedTest extends Model
     public function getRouteKeyName(): string
     {
         return 'level';
+    }
+
+    /**
+     * The Test Questions that are associated with the record.
+     *
+     * @return HasMany
+     */
+    public function testQuestions(): HasMany
+    {
+        return $this->hasMany(TestQuestion::class, 'seed_test_id', 'id');
     }
 }

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\FiltersRecordsByFields;
+use App\Traits\OrdersQueryResults;
+use App\Traits\Searchable;
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TestQuestion extends Model
+{
+    use FiltersRecordsByFields;
+    use HasFactory;
+    use OrdersQueryResults;
+    use Searchable;
+    use Uuids;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'test_questions';
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The default field used to order query results by.
+     *
+     * @var array
+     */
+    protected $orderByField = 'sort_id';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var array
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [];
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'sort_id',
+        'seed_test_id',
+        'question_number',
+        'question',
+        'answer',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id'              => 'string',
+        'sort_id'         => 'integer',
+        'seed_test_id'    => 'string',
+        'question_number' => 'integer',
+        'question'        => 'string',
+        'answer'          => 'boolean',
+    ];
+
+    /**
+     * The fields that should be searchable.
+     *
+     * @var array
+     */
+    protected $searchableFields = [
+        'question_number',
+        'question',
+        'answer',
+    ];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
+    protected $filterableFields = [
+        'question_number',
+        'question',
+        'answer',
+    ];
+
+    /*
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+}

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -3,16 +3,19 @@
 namespace App\Models;
 
 use App\Traits\FiltersRecordsByFields;
+use App\Traits\LoadsRelationsThroughServices;
 use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
 use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TestQuestion extends Model
 {
     use FiltersRecordsByFields;
     use HasFactory;
+    use LoadsRelationsThroughServices;
     use OrdersQueryResults;
     use Searchable;
     use Uuids;
@@ -78,6 +81,7 @@ class TestQuestion extends Model
         'question_number',
         'question',
         'answer',
+        'seedTest',
     ];
 
     /**
@@ -127,6 +131,22 @@ class TestQuestion extends Model
         'answer',
     ];
 
+    /**
+     * The relations that are available to include with the resource.
+     *
+     * @var array
+     */
+    protected $availableIncludes = [
+        'seedTest',
+    ];
+
+    /**
+     * The default relations to include with the resource.
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [];
+
     /*
      * Get the route key for the model.
      *
@@ -135,5 +155,15 @@ class TestQuestion extends Model
     public function getRouteKeyName(): string
     {
         return 'id';
+    }
+
+    /**
+     * The SeeD Test that the record belongs to.
+     *
+     * @return BelongsTo
+     */
+    public function seedTest(): BelongsTo
+    {
+        return $this->belongsTo(SeedTest::class, 'seed_test_id', 'id');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,6 +22,11 @@ class AppServiceProvider extends ServiceProvider
             \App\Contracts\Services\SeedTestService::class,
             \App\Services\SeedTestService::class
         );
+
+        $this->app->bind(
+            \App\Contracts\Services\TestQuestionService::class,
+            \App\Services\TestQuestionService::class
+        );
     }
 
     /**

--- a/app/Scopes/OrderQueryResults.php
+++ b/app/Scopes/OrderQueryResults.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class OrderQueryResults implements Scope
+{
+    /**
+     * Order the query results by what is configured on the model.
+     *
+     * @param Builder $builder The instance of the Eloquent query builder
+     * @param Model   $model   The instance of the current model
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        $builder->orderBy($model->getOrderByField(), $model->getOrderByDirection());
+    }
+}

--- a/app/Services/SeedTestService.php
+++ b/app/Services/SeedTestService.php
@@ -35,19 +35,21 @@ class SeedTestService implements SeedTestServiceContract
      */
     public function all(Request $request): array
     {
-        $query = $this->model->newModelQuery();
+        $query = $this->model->newQuery();
 
         if ($request->has('search')) {
             $query->search($request->search);
         }
 
-        return $query->filter($request->query())
-            ->orderBy(
-                $this->model->getOrderByField(),
-                $this->model->getOrderByDirection()
-            )
-            ->get()
-            ->toArray();
+        $includes = $this->model->parseIncludes(
+            $request->include ?: ''
+        );
+
+        $results = $query->with($includes)
+            ->filter($request->query())
+            ->get();
+
+        return $results->toArray();
     }
 
     /**
@@ -62,7 +64,12 @@ class SeedTestService implements SeedTestServiceContract
      */
     public function findOrFail(string $seedTestId, Request $request): array
     {
+        $includes = $this->model->parseIncludes(
+            $request->include ?: ''
+        );
+
         $data = $this->model
+            ->with($includes)
             ->where($this->model->getKeyName(), $seedTestId)
             ->orWhere($this->model->getRouteKeyName(), $seedTestId)
             ->first();

--- a/app/Services/TestQuestionService.php
+++ b/app/Services/TestQuestionService.php
@@ -35,19 +35,21 @@ class TestQuestionService implements TestQuestionServiceContract
      */
     public function all(Request $request): array
     {
-        $query = $this->model->newModelQuery();
+        $query = $this->model->newQuery();
 
         if ($request->has('search')) {
             $query->search($request->search);
         }
 
-        return $query->filter($request->query())
-            ->orderBy(
-                $this->model->getOrderByField(),
-                $this->model->getOrderByDirection()
-            )
-            ->get()
-            ->toArray();
+        $includes = $this->model->parseIncludes(
+            $request->include ?: ''
+        );
+
+        $results = $query->with($includes)
+            ->filter($request->query())
+            ->get();
+
+        return $results->toArray();
     }
 
     /**
@@ -62,7 +64,12 @@ class TestQuestionService implements TestQuestionServiceContract
      */
     public function findOrFail(string $testQuestionId, Request $request): array
     {
+        $includes = $this->model->parseIncludes(
+            $request->include ?: ''
+        );
+
         $data = $this->model
+            ->with($includes)
             ->where($this->model->getKeyName(), $testQuestionId)
             ->orWhere($this->model->getRouteKeyName(), $testQuestionId)
             ->first();

--- a/app/Services/TestQuestionService.php
+++ b/app/Services/TestQuestionService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Services\TestQuestionService as TestQuestionServiceContract;
+use App\Models\TestQuestion;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class TestQuestionService implements TestQuestionServiceContract
+{
+    /**
+     * The instance of the model to use for the service.
+     *
+     * @var TestQuestion
+     */
+    protected $model;
+
+    /**
+     * Create a new TestQuestionService instance.
+     *
+     * @param TestQuestion $model The instance of the model to use for the service
+     */
+    public function __construct(TestQuestion $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Retrieve all of the records in the database.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return array
+     */
+    public function all(Request $request): array
+    {
+        $query = $this->model->newModelQuery();
+
+        if ($request->has('search')) {
+            $query->search($request->search);
+        }
+
+        return $query->filter($request->query())
+            ->orderBy(
+                $this->model->getOrderByField(),
+                $this->model->getOrderByDirection()
+            )
+            ->get()
+            ->toArray();
+    }
+
+    /**
+     * Retrieve a specific record from the database, or fail if a record was not found.
+     *
+     * @param string  $testQuestionId The ID of the requested TestQuestion
+     * @param Request $request        The HTTP request from the client
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return array
+     */
+    public function findOrFail(string $testQuestionId, Request $request): array
+    {
+        $data = $this->model
+            ->where($this->model->getKeyName(), $testQuestionId)
+            ->orWhere($this->model->getRouteKeyName(), $testQuestionId)
+            ->first();
+
+        if (! $data) {
+            throw new NotFoundHttpException('The requested record could not be found.');
+        }
+
+        return $data->toArray();
+    }
+}

--- a/app/Traits/FiltersRecordsByFields.php
+++ b/app/Traits/FiltersRecordsByFields.php
@@ -20,31 +20,48 @@ trait FiltersRecordsByFields
      * Filter the records by the given criteria.
      *
      * @param Builder $query   The Eloquent Query Builder instance
-     * @param array   $filters An array of `key => value` pairs that correspond to `field => filter`
+     * @param array   $filters An array of `key => value` pairs that correspond to `column => filter`
      *
      * @return Builder
      */
     public function scopeFilter(Builder $query, array $filters): Builder
     {
+        $casts = $this->getCasts();
         $filters = array_intersect_key(
             $filters,
             array_flip($this->getFilterableFields())
         );
 
-        foreach ($filters as $key => $value) {
-            $pieces = explode(':', $value);
-            $hasLikeOperator = strtolower($pieces[0]) === 'like';
+        foreach ($filters as $column => $value) {
+            $type = array_key_exists($column, $casts) ? $casts[$column] : 'string';
+            $operator = '=';
 
-            if ($hasLikeOperator) {
+            // Check for a "like" operator.
+            $pieces = explode(':', $value);
+            if (strtolower($pieces[0]) === 'like') {
+                $operator = 'LIKE';
+
                 $impl = implode(':', array_slice($pieces, 1));
                 $value = "%{$impl}%";
             }
 
-            $query->where(
-                $key,
-                $hasLikeOperator ? 'LIKE' : '=',
-                $value
-            );
+            // Sanitize boolean values so they are not converted to "1" / "".
+            if (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+
+            /*
+             * Search for 'true' or 'false' with boolean fields rather than '1' or '0'.
+             * This will prevent issues where we are looking for an integer, but instead
+             * return a field with a boolean value rather than what was originally intended.
+             */
+            if ($type === 'boolean') {
+                $castStatement = "CASE WHEN {$column} = 1 THEN 'true' ELSE 'false' END";
+
+                $query->whereRaw("{$castStatement} {$operator} ?", $value);
+            } else {
+                $query->where($column, $operator, $value);
+            }
         }
 
         return $query;

--- a/app/Traits/LoadsRelationsThroughServices.php
+++ b/app/Traits/LoadsRelationsThroughServices.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+trait LoadsRelationsThroughServices
+{
+    /**
+     * Get the relations that are available to include with the resource.
+     *
+     * @return array
+     */
+    public function getAvailableIncludes(): array
+    {
+        return isset($this->availableIncludes) ? $this->availableIncludes : [];
+    }
+
+    /**
+     * Get the default relations to include with the resource.
+     *
+     * @return array
+     */
+    public function getDefaultIncludes(): array
+    {
+        return isset($this->defaultIncludes) ? $this->defaultIncludes : [];
+    }
+
+    /**
+     * Parse the requested includes and pluck only those that are valid.
+     *
+     * Note that this will only include relations that are two levels deep.
+     * Anything requested greater than two levels deep will be truncated.
+     *
+     * @param string $includes The requested includes in csv format
+     *
+     * @return array
+     */
+    public function parseIncludes(string $includes): array
+    {
+        $defaultIncludes = $this->getDefaultIncludes();
+        $validIncludes = [];
+
+        foreach (explode(',', $includes) as $rawInclude) {
+            $include = Str::camel($rawInclude);
+
+            /*
+             * If the relations are nested more than two levels deep from the resource,
+             * extract only the first two relations to limit the strain on the system.
+             * If a user is attempting to pull more than the second distant relation,
+             * they should look into restructuring their requests for optimizations.
+             */
+            if (substr_count($include, '.') > 2) {
+                $pieces = explode('.', $include);
+
+                $include = implode('.', array_slice($pieces, 0, 3));
+            }
+
+            if ($this->validateInclude($include)) {
+                $validIncludes[] = $include;
+            }
+        }
+
+        return array_unique(array_merge(
+            $defaultIncludes,
+            $validIncludes
+        ));
+    }
+
+    /**
+     * Validate the includes against what is explicitly defined on the model.
+     *
+     * @param string     $include The requested include
+     * @param Model|null $model   The model to validate the include against
+     *
+     * @return bool
+     */
+    public function validateInclude(string $include, ?Model $model = null): bool
+    {
+        $model = $model ?: $this;
+
+        $availableIncludes = $model->getAvailableIncludes();
+
+        if (strpos($include, '.') !== false) {
+            $includeArray = explode('.', $include, 2);
+
+            if (! in_array($includeArray[0], $availableIncludes)) {
+                return false;
+            }
+
+            return $this->validateInclude(
+                $includeArray[1],
+                $model->{$includeArray[0]}()->getRelated()
+            );
+        }
+
+        return in_array($include, $availableIncludes);
+    }
+}

--- a/app/Traits/OrdersQueryResults.php
+++ b/app/Traits/OrdersQueryResults.php
@@ -2,6 +2,8 @@
 
 namespace App\Traits;
 
+use App\Scopes\OrderQueryResults;
+
 trait OrdersQueryResults
 {
     /**
@@ -21,6 +23,14 @@ trait OrdersQueryResults
      */
     public function getOrderByDirection(): string
     {
-        return isset($this->orderByDirection) ? $this->orderByDirection : 'desc';
+        return isset($this->orderByDirection) ? $this->orderByDirection : 'asc';
+    }
+
+    /**
+     * Bootstrap the trait on the model.
+     */
+    protected static function bootOrdersQueryResults()
+    {
+        static::addGlobalScope(new OrderQueryResults());
     }
 }

--- a/app/Traits/Searchable.php
+++ b/app/Traits/Searchable.php
@@ -26,10 +26,29 @@ trait Searchable
      */
     public function scopeSearch(Builder $query, mixed $value): Builder
     {
-        foreach ($this->getSearchableFields() as $key => $column) {
-            $clause = 0 === $key ? 'where' : 'orWhere';
+        // Sanitize boolean values so they are not converted to "1" / "".
+        if (is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
 
-            $query->{$clause}($column, 'LIKE', "%{$value}%");
+        foreach ($this->getSearchableFields() as $key => $column) {
+            $clause = $key === 0 ? 'where' : 'orWhere';
+            $casts = $this->getCasts();
+            $type = array_key_exists($column, $casts) ? $casts[$column] : 'string';
+
+            /*
+             * Search for 'true' or 'false' with boolean fields rather than '1' or '0'.
+             * This will prevent issues where we are looking for an integer, but instead
+             * return a field with a boolean value rather than what was originally intended.
+             */
+            if ($type === 'boolean') {
+                $clause = "{$clause}Raw";
+                $castStatement = "CASE WHEN {$column} = 1 THEN 'true' ELSE 'false' END";
+
+                $query->{$clause}("{$castStatement} LIKE ?", "%{$value}%");
+            } else {
+                $query->{$clause}($column, 'LIKE', "%{$value}%");
+            }
         }
 
         return $query;

--- a/app/Traits/Uuids.php
+++ b/app/Traits/Uuids.php
@@ -7,12 +7,10 @@ use Webpatser\Uuid\Uuid;
 trait Uuids
 {
     /**
-     * Bootstrap the model and its traits.
+     * Bootstrap the trait on the model.
      */
-    protected static function boot()
+    protected static function bootUuids()
     {
-        parent::boot();
-
         static::creating(function ($model) {
             $model->{$model->getKeyName()} = Uuid::generate(4)->string;
         });

--- a/database/factories/TestQuestionFactory.php
+++ b/database/factories/TestQuestionFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TestQuestion;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TestQuestionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = TestQuestion::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'seed_test_id' => null,
+            'sort_id' => $this->faker->unique()->numberBetween(1, 300),
+            'question_number' => $this->faker->numberBetween(1, 10),
+            'question' => $this->faker->paragraph,
+            'answer' => $this->faker->boolean(50),
+        ];
+    }
+}

--- a/database/migrations/2021_08_27_223632_create_test_questions_table.php
+++ b/database/migrations/2021_08_27_223632_create_test_questions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestQuestionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('test_questions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->integer('sort_id');
+            $table->uuid('seed_test_id')->nullable();
+            $table->integer('question_number');
+            $table->text('question');
+            $table->boolean('answer');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('test_questions');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(SeedRanksTableSeeder::class);
         $this->call(SeedTestsTableSeeder::class);
+        $this->call(TestQuestionsTableSeeder::class);
     }
 }

--- a/database/seeders/TestQuestionsTableSeeder.php
+++ b/database/seeders/TestQuestionsTableSeeder.php
@@ -1,0 +1,1879 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\SeedTest;
+use App\Models\TestQuestion;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class TestQuestionsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $testQuestions = $this->getTestQuestions();
+
+        $sortId = 1;
+        foreach ($testQuestions as $key => $question) {
+            $testQuestions[$key]['id'] = Uuid::generate(4);
+            $testQuestions[$key]['sort_id'] = $sortId;
+            $testQuestions[$key]['created_at'] = Carbon::now();
+            $testQuestions[$key]['updated_at'] = Carbon::now();
+            $sortId++;
+        }
+
+        $testQuestion = new TestQuestion();
+
+        $testQuestion->insert($testQuestions);
+    }
+
+    /**
+     * The Test Questions to be inserted into the database.
+     *
+     * @return array
+     */
+    protected function getTestQuestions(): array
+    {
+        $seedTests = (new SeedTest())->all();
+
+        return [
+            // Level 1
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 1,
+                'question' => 'The Draw command extracts magic from enemies.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 2,
+                'question' => 'GF stands for Garden Fighter.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 3,
+                'question' => 'There are a total of 8 elemental attributes.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 4,
+                'question' => 'In battle, a higher Strength stat causes more physical damage.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 5,
+                'question' => 'HP-J is a junction ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 6,
+                'question' => "You can't assign specific abilities for your GF to learn.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 7,
+                'question' => 'Magic uses MP.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 8,
+                'question' => 'You can name your GF.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 9,
+                'question' => 'You can wear protective gear.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 1)->id,
+                'question_number' => 10,
+                'question' => 'GF level up with AP.',
+                'answer' => false,
+            ],
+            // Level 2
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 1,
+                'question' => 'You can raise your Vitality by junctioning magic.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 2,
+                'question' => "Squall's weapon is the Gauntlet",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 3,
+                'question' => 'You can Stock drawn magic.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 4,
+                'question' => 'Any action taken while Poisoned causes damage. There is no damage if you take no action.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 5,
+                'question' => 'Being hit by a physical attack removes Confuse.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 6,
+                'question' => "Squall's Limit Break is Kenzokuken.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 7,
+                'question' => 'To junction magic, you need a matching junction ability for the stat you want to junction.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 8,
+                'question' => '<Junction Ability Icon> signifies a Junction Ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 9,
+                'question' => 'The 8 elements are Fire, Ice, Thunder, Poison, Earth, Sorcery, Wind, and Holy.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 2)->id,
+                'question_number' => 10,
+                'question' => 'There is a limit to how much magic you can draw from monsters.',
+                'answer' => false,
+            ],
+            // Level 3
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 1,
+                'question' => "Potions can restore a GF's HP.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 2,
+                'question' => 'Magic can only by acquired by drawing from enemies.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 3,
+                'question' => "Selphie's weapon is the nunchaku",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 4,
+                'question' => 'You only need money to remodel your weapon.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 5,
+                'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 6,
+                'question' => 'GF also have levels: the higher their levels, the stronger their attacks.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 7,
+                'question' => '<Command Ability Icon> signifies Command Ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 8,
+                'question' => 'Each party member can have up to 5 Character and Party Abilities.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 9,
+                'question' => 'Command Abilities must be set to be used in battle.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 3)->id,
+                'question_number' => 10,
+                'question' => 'AP means Action Point.',
+                'answer' => false,
+            ],
+            // Level 4
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 1,
+                'question' => 'Only Squall can use a gunblade.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 2,
+                'question' => 'Attack magic can be used against party members.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 3,
+                'question' => 'There is an ability that allows you to make magic from items.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 4,
+                'question' => 'Higher Vitality reduces physical damage.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 5,
+                'question' => 'Blue Magic is learned by being attacked by a monster',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 6,
+                'question' => 'The magic Dispel cures poison.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 7,
+                'question' => "If you are KO'd with status change, but are revived after battle, the status change is removed.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 8,
+                'question' => "T-Rexaur is a monster that lives in Balamb Garden's training center.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 9,
+                'question' => "Squall's gunblade causes more damage by pressing <L2> at the right time.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 4)->id,
+                'question_number' => 10,
+                'question' => 'You can stock up to 255 of each magic.',
+                'answer' => false,
+            ],
+            // Level 5
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 1,
+                'question' => '<Character Ability Icon> signifies a party ability.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 2,
+                'question' => 'You can Draw from party members.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 3,
+                'question' => 'You can save the game anywhere.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 4,
+                'question' => 'When a GF learns an ability, some new abilities may appear.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 5,
+                'question' => 'A Character Ability must be set; otherwise, it is useless.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 6,
+                'question' => 'The higher the Speed stat, the better your chances of using a Limit Break.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 7,
+                'question' => 'An ability is something you learn by gaining EXP.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 8,
+                'question' => 'Under Zombie, you succumb more easily to Holy attacks.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 9,
+                'question' => "'Physical Attack' means harm caused by use of weapons like swords and guns.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 5)->id,
+                'question_number' => 10,
+                'question' => 'You can steal Steel Pipe from a Wendigo.',
+                'answer' => true,
+            ],
+            // Level 6
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 1,
+                'question' => "Zell's weapons are gloves.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 2,
+                'question' => 'You can still summon GF while Silenced.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 3,
+                'question' => 'Ifrit can learn the F Mag-RF ability',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 4,
+                'question' => 'If more than 1 GF with the same junction ability is junctioned to a character, the effect of those abilities remains the same.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 5,
+                'question' => 'All status changes return to normal after battle.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 6,
+                'question' => 'You can use the Attack and Draw commands without junctioning a GF.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 7,
+                'question' => "When you set Squall's gunblade on auto, there is no need to press <R1>",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 8,
+                'question' => 'The Mag stat determines the strength and effectiveness of magic.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 9,
+                'question' => 'When using Auto to junction, you can only choose Atk or Def.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 6)->id,
+                'question_number' => 10,
+                'question' => 'A Grat uses Sleep attacks.',
+                'answer' => true,
+            ],
+            // Level 7
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 1,
+                'question' => 'Evade indicates how well you can evade physical attacks. Higher Eva stat reduces hits from physical attack.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 2,
+                'question' => 'Using Fire against enemies that absorb Fire raises their HP.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 3,
+                'question' => "Squall's finishing blow is different depending on the type of gunblade he uses.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 4,
+                'question' => 'By using F Mag-RF, you can refine 5 Fires from 1 M-Stone Piece.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 5,
+                'question' => 'Only 1 rare card exists in the whole world.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 6,
+                'question' => 'A Buel sometimes uses Fire.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 7,
+                'question' => 'Spirit only relates to using Confuse. Higher Spr stat increases the likelihood of success when using Confuse.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 8,
+                'question' => 'A Geezard drops many Screws.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 9,
+                'question' => 'Enemies level up as you do.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 7)->id,
+                'question_number' => 10,
+                'question' => 'You encounter fewer enemies on the World Map if you walk instead of run.',
+                'answer' => false,
+            ],
+            // Level 8
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 1,
+                'question' => "Galbadian Soldiers don't use magic.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 2,
+                'question' => 'Weapons can be remodeled into more powerful models at the Junk Shop.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 3,
+                'question' => '<Party Ability Icon> signifies Character Ability.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 4,
+                'question' => "Casting Slow over Haste will cancel Haste and return the target's status back to 
+                normal.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 5,
+                'question' => 'You encounter more enemies in the forest than the plains on the World Map.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 6,
+                'question' => "When Elem-Def goes over 100%, that element's damage will be absorbed.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 7,
+                'question' => 'The Garden exists only in Balamb.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 8,
+                'question' => 'There are no Bombs in the Fire Cavern.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 9,
+                'question' => 'Each GF can learn different abilities.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 8)->id,
+                'question_number' => 10,
+                'question' => 'Junk Shops sell weapons.',
+                'answer' => false,
+            ],
+            // Level 9
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 1,
+                'question' => 'You can cast the GF you drew instead of Stock.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 2,
+                'question' => '<Menu Ability Icon> signifies Menu Ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 3,
+                'question' => "Magic listed in Selphie's Limit Break is magic she owns.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 4,
+                'question' => 'If a GF is hardly used, or has low compatibility with party members, it may leave your party.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 5,
+                'question' => 'Party Abilities can be used without setting them as abilities.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 6,
+                'question' => "GF left KO'd too long perish and cannot be revived.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 7,
+                'question' => '1 Sharp Spike refines into 5 AP Ammo.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 8,
+                'question' => ' Defeating the enemy who caused a status change returns status to normal.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 9,
+                'question' => 'Enemies change attack patterns as you level up.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 9)->id,
+                'question_number' => 10,
+                'question' => 'When Poisoned, every action you take damages you.',
+                'answer' => true,
+            ],
+            // Level 10
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 1,
+                'question' => 'Use the magic Confuse to inflict confuse status on your enemy.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 2,
+                'question' => ' A Potion restores 100 HP.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 3,
+                'question' => "Quistis' weapon is a magic sword.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 4,
+                'question' => 'ATB stands for Ability Tone Black.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 5,
+                'question' => 'You are more susceptible to fire under Zombie.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 6,
+                'question' => 'You can refine 1 Tent from 1 Healing Water by using the Menu Ability Tool-RF.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 7,
+                'question' => 'EXP are divided equally among all characters participating in battle.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 8,
+                'question' => "Blind sucks out an enemy's brain to prevent him from attacking.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 9,
+                'question' => 'Esuna or Soft removes petrify.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 10)->id,
+                'question_number' => 10,
+                'question' => 'Nothing removes Sleep.',
+                'answer' => false,
+            ],
+            // Level 11
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 1,
+                'question' => 'GF can regain HP while walking.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 2,
+                'question' => 'The Draw command must be set in order to use a Draw Point.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 3,
+                'question' => 'Limit Breaks always kill enemies.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 4,
+                'question' => 'Siren can learn the ability Treatment.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 5,
+                'question' => 'You can junction more than one GF.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 6,
+                'question' => 'Adamantine is an item dropped by a level 10 Adamantoise.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 7,
+                'question' => 'You can rearrange the magic and items displayed during battle.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 8,
+                'question' => 'Shiva can learn Doom right after becoming an ally.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 9,
+                'question' => "Drain absorbs HP from enemies, but can't be used to absorb from party members.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 11)->id,
+                'question_number' => 10,
+                'question' => 'Recovery magic damages Undead monsters.',
+                'answer' => true,
+            ],
+            // Level 12
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 1,
+                'question' => 'Armadodo absorbs Earth attacks.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 2,
+                'question' => 'You can refine 20 Curas from 1 Healing Water by using L Mag-RF.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 3,
+                'question' => "You receive EXP after the battle is won even when KO'd.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 4,
+                'question' => 'You can only draw GF from an enemy or defeat a GF to make them yours.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 5,
+                'question' => 'The maximum number of magic that can be drawn from an enemy in one turn is 9.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 6,
+                'question' => "You can't steal Sharp Spike from a Grand Mantis.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 7,
+                'question' => 'Press <Select> to hide battle commands temporarily in battle.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 8,
+                'question' => 'Magic and GF commands are the only commands disabled by Silence.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 9,
+                'question' => 'You can use Scan on party members.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 12)->id,
+                'question_number' => 10,
+                'question' => "If you set Poison magic(100%) to ST-Def-J, you don't receive damage from poisonous physical attacks.",
+                'answer' => false,
+            ],
+            // Level 13
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 1,
+                'question' => 'You gain EXP for the damage you inflict on enemies, even if you run away.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 2,
+                'question' => 'You can mug Blue Spikes from a Chimera.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 3,
+                'question' => 'GF abilities must be set to a party member for use, or it is ineffective.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 4,
+                'question' => 'You can only Draw once from any Draw Point.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 5,
+                'question' => 'GF Quezacotl can learn the Card Mod ability without using an item.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 6,
+                'question' => "When you fail to Draw a number of times, you can't use the Draw ability for a while.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 7,
+                'question' => "When a GF is KO'd, its compatibilty goes down with the junctioned party member.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 8,
+                'question' => 'You can run from any enemy if you take enough time.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 9,
+                'question' => "You must have ammo to pull Squall's gunblade trigger.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 13)->id,
+                'question_number' => 10,
+                'question' => 'When you attack a Fire monster, you always receive Fire damage.',
+                'answer' => false,
+            ],
+            // Level 14
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 1,
+                'question' => 'You can draw some GF from enemies.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 2,
+                'question' => 'In critical situations, Squall can use Renzokuken more often.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 3,
+                'question' => "Higher the Hit stat, higher the accuracy of physical attacks, but if the enemy's Evade is high, you may still miss.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 4,
+                'question' => 'Some items affect the compatibility value between GF and party members.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 5,
+                'question' => 'Under Shell, magic damage is reduced to 1/4 of its usual amount.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 6,
+                'question' => 'There is a monster called Belhelmel.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 7,
+                'question' => "You can only use the Attack command in battle if no GF are junctioned, or command abilities aren't set.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 8,
+                'question' => 'Defeating enemies by physical attacks rather than magical attacks gives you more EXP.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 9,
+                'question' => 'Cover only protects a party member standing next to you.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 14)->id,
+                'question_number' => 10,
+                'question' => 'Pressing <Square> continuously is the best way to use Boost.',
+                'answer' => false,
+            ],
+            // Level 15
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 1,
+                'question' => 'Compatibility with GF increases as you summon them.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 2,
+                'question' => "It's not possible for one member to hold all types of magic.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 3,
+                'question' => "Fastitocalon's Sand Storm is a Wind attack.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 4,
+                'question' => 'You can use Reflect to reflect magic that has already been reflected.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 5,
+                'question' => "Confuse doesn't make you attack yourself.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 6,
+                'question' => 'You can refine Arctic Wind into Blizzard by using an ability.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 7,
+                'question' => 'GF Cerberus can learn the Spd Bonus ability.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 8,
+                'question' => "Party members under Silence can't use magic, even in the menu.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 9,
+                'question' => 'Echo Screen cures Petrify.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 15)->id,
+                'question_number' => 10,
+                'question' => 'When afflicted with Silence while summoning GF, the summoning stops.',
+                'answer' => true,
+            ],
+            // Level 16
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 1,
+                'question' => 'You can use Limit Breaks more often your HP is low.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 2,
+                'question' => 'When you junction with a GF who learned Elem-Def-J and Elem-Defx2, you can junction 3 magic to Elem-Def slots.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 3,
+                'question' => 'There is a command to remove GF without losing magic on the menu junction screen.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 4,
+                'question' => "There are enemies whose status doesn't change, even if your ST-Atk-J is set at 100%.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 5,
+                'question' => 'Draw means drawing magic stocked by a monster. When it runs out of stock, it can no longer use magic.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 6,
+                'question' => 'Low level Bite Bugs drop M-Stone Pieces.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 7,
+                'question' => "G-Mega-Potion Revives a KO'd GF.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 8,
+                'question' => 'The game is over when all party members are afflicted with Death, Zombie, or Petrify.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 9,
+                'question' => 'Hi-Potion restores 1,000 HP.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 16)->id,
+                'question_number' => 10,
+                'question' => 'Walk-Gil is an ability to acquire Gil by walking on the field.',
+                'answer' => false,
+            ],
+            // Level 17
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 1,
+                'question' => 'You can use Limit Breaks more frequently under Aura.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 2,
+                'question' => "G-Potion, which restores GF's HP, can also be used in battle.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 3,
+                'question' => 'The Med Data ability enables the use of 2 potions in 1 turn.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 4,
+                'question' => "Finishing blows come out more often if you time the trigger for Squall's Renzokuken correctly.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 5,
+                'question' => 'Set the ability Alert to avoid back attacks.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 6,
+                'question' => 'Limit Breaks activate when Berserked.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 7,
+                'question' => 'You can use Potions to cure a zombied party members in the menu.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 8,
+                'question' => "GF Alexander's attacks are Holy attacks.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 9,
+                'question' => 'T-Rexaur sometimes drops Dinosaur Fangs.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 17)->id,
+                'question_number' => 10,
+                'question' => 'Under Darkness, you are blinded, and may attack party members.',
+                'answer' => false,
+            ],
+            // Level 18
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 1,
+                'question' => "You can't junction witout GF, no matter how high your level.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 2,
+                'question' => 'Reflect can turn away any magic.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 3,
+                'question' => 'There are a total of 30 different statuses.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 4,
+                'question' => 'There is no magic that cures Zombie.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 5,
+                'question' => 'When choosing a target in battle, press <L1> to choose your target from a window.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 6,
+                'question' => 'There is 1 ability you can learn by yourself.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 7,
+                'question' => 'After receiving magic damage, Wendigo lands to shoot Pulse Ammo from its mouth.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 8,
+                'question' => 'HP is restored slowly in Sleep.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 9,
+                'question' => 'GF Carbuncle casts Shell and Protect on all party members.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 18)->id,
+                'question_number' => 10,
+                'question' => 'Confuse takes precedence over Berserk when the 2 are cast simultaneously.',
+                'answer' => false,
+            ],
+            // Level 19
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 1,
+                'question' => 'Defense against Death is determined by Death% stat in ST-Def-J.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 2,
+                'question' => 'Zombied party members take damage if they use Drain on a Zombie enemy.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 3,
+                'question' => 'Cockatrice bites can sometimes be poisonous.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 4,
+                'question' => 'Invincible status returns to normal after battle.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 5,
+                'question' => 'The Chimera has dragon, frog, goat, bird, and wild boar heads.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 6,
+                'question' => 'Protect is not effective while Vitality is zero.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 7,
+                'question' => 'You float higher each time you cast Float.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 8,
+                'question' => 'You must run from X-ATM092, as it is invincible.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 9,
+                'question' => "Break turns an enemy's Spirit to zero, so it has no effect on enemies with zero Spirit.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 19)->id,
+                'question_number' => 10,
+                'question' => 'With weapons learned from Weapons Monthly, the Junk Shop tells you which items you need in gray.',
+                'answer' => true,
+            ],
+            // Level 20
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 1,
+                'question' => "You don't encounter enemies while in a car.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 2,
+                'question' => '1 Inferno Fang refines into 20 Flares.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 3,
+                'question' => 'A Gayla is about 12 meters tall.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 4,
+                'question' => 'There are some non-elemental monsters that have no elemental attributes.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 5,
+                'question' => 'When your SeeD level goes up, your Magic power and Draw success rates go up.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 6,
+                'question' => "The damage you inflict on enemies doesn't change even if your HP is running low.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 7,
+                'question' => 'High compatibility with GF assures a shorter summoning time.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 8,
+                'question' => 'A Caterchipillar sometimes drops Spider Webs.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 9,
+                'question' => 'Setting Str+20% and Str+40% is more effective than setting Str+60% alone.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 20)->id,
+                'question_number' => 10,
+                'question' => "GF Siren's attack is physical damage plus Confusion.",
+                'answer' => false,
+            ],
+            // Level 21
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 1,
+                'question' => 'Bombs sometimes self-detonate.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 2,
+                'question' => 'Malboros lurk in North Esthar.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 3,
+                'question' => 'Combat King is a magazine that introduces combat skills.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 4,
+                'question' => 'You can draw a GF from Elvoret on the communication tower.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 5,
+                'question' => 'Even if afflicted with Stop while summoning a GF, summoning continues, because the GF is not affected by Stop.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 6,
+                'question' => 'Defend protects you from all physical attacks, but magic attacks can still inflict damage.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 7,
+                'question' => 'Junction Life to raise defense against all elemental attributes.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 8,
+                'question' => 'There is a libary in Balamb Garden.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 9,
+                'question' => 'Mega Phoenix is an item that casts Phoenix Down on all party members.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 21)->id,
+                'question_number' => 10,
+                'question' => 'You can refine 1 Bomb Spirit from 1 Bomb Card.',
+                'answer' => false,
+            ],
+            // Level 22
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 1,
+                'question' => 'Casting Protect over Shell cancels Shell, leaving the party member only with Protect.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 2,
+                'question' => 'You may drop Gil and Items if your Luck stat is low.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 3,
+                'question' => 'To defend against Fire attacks, Junction Ice magic to Elem-Def-J.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 4,
+                'question' => 'Junctioning Reflect to ST-Def raises your defense stat in 9 slots.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 5,
+                'question' => 'Zombie and Pain are Sorcery elemental magic.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 6,
+                'question' => 'There is an Item called Hi-Potion+ that restores 3,000 HP.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 7,
+                'question' => 'When your SeeD level goes up, shops give you a discount.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 8,
+                'question' => "If you use the same elemental magic used in a GF's attack, your compatibility goes up.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 9,
+                'question' => 'When new info is acquired, more explanations may be added to the Help menu.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 22)->id,
+                'question_number' => 10,
+                'question' => 'A higher Hit stat affects the success rate of Draw.',
+                'answer' => false,
+            ],
+            // Level 23
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 1,
+                'question' => 'You can make Remedy+ from Remedy.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 2,
+                'question' => "Hold down <R1><R2> simultaneously to escape from battle. (But sometimes you can't run.)",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 3,
+                'question' => 'The command ability Recover can revive party members from KO.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 4,
+                'question' => 'Esuna removes status changes, and Dispel removes elemental changes.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 5,
+                'question' => 'Under Regen, HP is restored regulary, even if you are afflicted with Stop.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 6,
+                'question' => "You can't use any Limit Breaks when Cursed.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 7,
+                'question' => 'Berserk raises attack power, but the only command activated is Attack.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 8,
+                'question' => 'There is an ability to make Remedy from Malboro Tentacles.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 9,
+                'question' => 'Float expires after a certain time.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 23)->id,
+                'question_number' => 10,
+                'question' => 'Protect reduces physical damage by 1/2.',
+                'answer' => true,
+            ],
+            // Level 24
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 1,
+                'question' => 'Use Esuna to cure Slow.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 2,
+                'question' => 'Setting Float to Elem-Def-J raises defense against Earth elemental attacks.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 3,
+                'question' => 'The ATB runs even while a GF is appearing.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 4,
+                'question' => "Auto Reflect casts Reflect on you as long as you don't fall under KO.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 5,
+                'question' => '<GF Ability Icon> signifies GF ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 6,
+                'question' => 'There are a limited number of abilities a GF can learn.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 7,
+                'question' => 'Protect keeps reducing damage with each use.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 8,
+                'question' => 'You get Poison along with HP when using Drain against a poisoned target.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 9,
+                'question' => 'A weapon can break after multiple battles. (It can be fixed.)',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 24)->id,
+                'question_number' => 10,
+                'question' => 'If you are Silenced while you are afflicted with Confuse, you cannot use magic.',
+                'answer' => true,
+            ],
+            // Level 25
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 1,
+                'question' => 'You can mug a Laser Cannon from an enemy called Elastoid.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 2,
+                'question' => "GF Leviathan's skill Tsunami causes a forest fire.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 3,
+                'question' => 'Use Amnesia Greens to make a GF forget to an ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 4,
+                'question' => "There is an ability to see Save Points and Draw Points you can't usually see.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 5,
+                'question' => 'GF gains more EXP if only 1 GF is junctioned to a party member.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 6,
+                'question' => 'It is good to return to Balamb Garden once in a while to collect your SeeD salary.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 7,
+                'question' => 'The magic Watera and Waterga are more powerful than magic Water.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 8,
+                'question' => "Counter doesn't react to attacks which affect all party members.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 9,
+                'question' => "GF can learn an ability to succeed in every Mug by using an Item called Bandit's Hand.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 25)->id,
+                'question_number' => 10,
+                'question' => 'You can Draw magic that causes Curse.',
+                'answer' => false,
+            ],
+            // Level 26
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 1,
+                'question' => 'Using Drain on the undead damages you.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 2,
+                'question' => 'The Character ability Initiative enables you to begin battle with a full ATB gauge, even while you are back-attacked.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 3,
+                'question' => 'The Command Ability, Darkside, inflicts Darkness on a target when you make a physical attack.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 4,
+                'question' => 'Holy is the only Holy elemental magic.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 5,
+                'question' => 'Even GFs that are not junctioned gain EXP and AP.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 6,
+                'question' => 'Shell reduces the effectiveness of recovery magic by half.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 7,
+                'question' => 'With a high Evade stat, you sometimes evade attacks even when under Sleep.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 8,
+                'question' => 'You can make GF forget an ability.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 9,
+                'question' => 'Doom continues counting down in the field even after you run from battle.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 26)->id,
+                'question_number' => 10,
+                'question' => 'Attack magic is more effective if your Strength, rather than Magic stat is high.',
+                'answer' => false,
+            ],
+            // Level 27
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 1,
+                'question' => "Haste reduces Draw's success rate.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 2,
+                'question' => 'Your SeeD salary relates to how many enemies you have defeated.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 3,
+                'question' => 'The Double GF ability summons multiple GF simultaneously.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 4,
+                'question' => 'Choose Rearrange in the menu to rearrange items automatically.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 5,
+                'question' => 'Every monster has a weakness.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 6,
+                'question' => "Bio weakens the target's cell structure to make the body more vulnerable.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 7,
+                'question' => "It's harder to run when back-attacked.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 8,
+                'question' => 'Flare is a Fire elemental magic.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 9,
+                'question' => 'You can find out how many monsters you have defeated.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 27)->id,
+                'question_number' => 10,
+                'question' => 'Party members not participating in battle also receive a small amount of EXP.',
+                'answer' => false,
+            ],
+            // Level 28
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 1,
+                'question' => 'A higher Speed stat fills the ATB gauge faster.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 2,
+                'question' => 'You can remove Doom with Esuna.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 3,
+                'question' => 'Magic attack means attacking with any type of magic, except for Holy magic.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 4,
+                'question' => 'No magic removes doom.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 5,
+                'question' => 'Pain inflicts Poison, Silence, and Darkness on enemies, but sometimes not all 3 status changes will occur.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 6,
+                'question' => 'Staying at a hotel removes status changes and restores all HP.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 7,
+                'question' => "You can stop Squall's Renzokuken by pressing <X>",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 8,
+                'question' => 'Double or Triple lets you use the same magic multiple times.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 9,
+                'question' => 'Petrify wears off after time passes.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 28)->id,
+                'question_number' => 10,
+                'question' => "Using Soft while Petrifying won't stop the countdown.",
+                'answer' => false,
+            ],
+            // Level 29
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 1,
+                'question' => 'Phoenix Heart restores your party members from KO.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 2,
+                'question' => "A GF in KO is revived in the next battle, even if you don't revive it.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 3,
+                'question' => 'Casting Double while under Double turns the status into Triple.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 4,
+                'question' => 'Mag Up raises the Mag stat by 1.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 5,
+                'question' => 'The ability Rare Item changes the probability of enemies dropping items.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 6,
+                'question' => 'The Galbadian soldier Biggs, who was on the communication tower, is a colonel.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 7,
+                'question' => 'You need at least 3 magic in stock to use Triple.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 8,
+                'question' => 'If 2 party members are under Zombie and you become inflicted by confuse, game is over.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 9,
+                'question' => 'Meteor chooses targets randomly from the enemy group.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 29)->id,
+                'question_number' => 10,
+                'question' => 'Meltdown is a magic attack that melts enemies.',
+                'answer' => false,
+            ],
+            // Level 30
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 1,
+                'question' => 'It is good to use Float when fighting Thrustaevis, who uses Earthquakes.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 2,
+                'question' => "There is no point using Life or Full-life on party members who haven't been KO'd.",
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 3,
+                'question' => 'If you receive 800 HP damage while summoning a GF with 500 HP, the difference of 300 HP are received by the summoner.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 4,
+                'question' => "Torama sometimes drops an item called Torama's Beard.",
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 5,
+                'question' => 'Casting Aura under Curse will bring your status back to normal.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 6,
+                'question' => 'There is a monster called GraBia on the Galbadia continent.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 7,
+                'question' => 'Silence is not removed, even after battle.',
+                'answer' => true,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 8,
+                'question' => 'Reflect always returns magic to the one who cast it.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 9,
+                'question' => 'Status can change while under Petrify.',
+                'answer' => false,
+            ],
+            [
+                'seed_test_id' => $seedTests->first(fn ($v) => $v->level === 30)->id,
+                'question_number' => 10,
+                'question' => 'The only way for GF to learn abilities is to gain AP (Ability Points).',
+                'answer' => false,
+            ],
+        ];
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
+use App\Http\Controllers\V0\TestQuestionController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/')->uses([HealthCheckController::class, 'status']);
@@ -12,3 +13,6 @@ Route::get('/seed-ranks/{rank}')->uses([SeedRankController::class, 'show']);
 
 Route::get('/seed-tests/')->uses([SeedTestController::class, 'index']);
 Route::get('/seed-tests/{test}')->uses([SeedTestController::class, 'show']);
+
+Route::get('/test-questions/')->uses([TestQuestionController::class, 'index']);
+Route::get('/test-questions/{id}')->uses([TestQuestionController::class, 'show']);

--- a/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
@@ -1,0 +1,498 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\TestQuestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TestQuestionEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_test_questions()
+    {
+        $testQuestions = TestQuestion::factory()->count(10)->create();
+
+        $response = $this->get('/v0/test-questions');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_test_question_using_the_id_key()
+    {
+        $testQuestion = TestQuestion::factory()->create();
+
+        $response = $this->get("/v0/test-questions/{$testQuestion->id}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $testQuestion->id,
+                'sort_id' => $testQuestion->sort_id,
+                'seed_test_id' => $testQuestion->seed_test_id,
+                'question_number' => $testQuestion->question_number,
+                'question' => $testQuestion->question,
+                'answer' => $testQuestion->answer,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/v0/test-questions/invalid');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_question_number_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?search=1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_question_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?search=can');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_answer_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?search=false');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_number_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?question_number=1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?question_number=like:1');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get("/v0/test-questions?question=Potions can restore a GF's HP.");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?question=like:can');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_answer_column()
+    {
+        TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        $two = TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?answer=true');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $two->id,
+                    'sort_id' => $two->sort_id,
+                    'seed_test_id' => $two->seed_test_id,
+                    'question_number' => $two->question_number,
+                    'question' => $two->question,
+                    'answer' => $two->answer,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $response = $this->get('/v0/test-questions?answer=like:f');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Endpoints\V0;
 
+use App\Http\Transformers\V0\SeedTestTransformer;
+use App\Models\SeedTest;
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -95,7 +97,7 @@ class TestQuestionEndpointTest extends TestCase
         $response = $this->get('/v0/test-questions?search=1');
 
         $response->assertStatus(200);
-        $response->assertExactJson([
+        $response->assertJson([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
@@ -492,6 +494,64 @@ class TestQuestionEndpointTest extends TestCase
                     'question' => $three->question,
                     'answer' => $three->answer,
                 ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions()
+    {
+        $testQuestions = TestQuestion::factory()
+            ->count(10)
+            ->for(SeedTest::factory())
+            ->create();
+
+        $response = $this->get('/v0/test-questions?include=seed-test');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'seed_test' => [
+                        // An array of SeeD Test data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_seed_test_relation_on_an_individual_test_question()
+    {
+        $testQuestion = TestQuestion::factory()
+            ->for(SeedTest::factory())
+            ->create();
+
+        $seedTestTransformer = $this->app->make(SeedTestTransformer::class);
+        $response = $this->get("/v0/test-questions/{$testQuestion->id}?include=seed-test");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $testQuestion->id,
+                'sort_id' => $testQuestion->sort_id,
+                'seed_test_id' => $testQuestion->seed_test_id,
+                'question_number' => $testQuestion->question_number,
+                'question' => $testQuestion->question,
+                'answer' => $testQuestion->answer,
+                'seed_test' => $seedTestTransformer->transformRecord($testQuestion->seedTest->toArray()),
             ],
         ]);
     }

--- a/tests/Unit/Controllers/V0/TestQuestionControllerTest.php
+++ b/tests/Unit/Controllers/V0/TestQuestionControllerTest.php
@@ -1,0 +1,526 @@
+<?php
+
+namespace Tests\Unit\Controllers\V0;
+
+use App\Contracts\Services\TestQuestionService;
+use App\Http\Controllers\V0\TestQuestionController;
+use App\Http\Transformers\V0\TestQuestionTransformer;
+use App\Models\TestQuestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class TestQuestionControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_test_questions()
+    {
+        $testQuestions = TestQuestion::factory()->count(10)->create();
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request());
+
+        $this->assertArraySubset([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ], $response->getData(true));
+        $this->assertCount(10, $response->getData(true)['data']);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_test_question_using_the_id_key()
+    {
+        $testQuestion = TestQuestion::factory()->create();
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->show(new Request(), $testQuestion->id);
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $testQuestion->id,
+                'sort_id' => $testQuestion->sort_id,
+                'seed_test_id' => $testQuestion->seed_test_id,
+                'question_number' => $testQuestion->question_number,
+                'question' => $testQuestion->question,
+                'answer' => $testQuestion->answer,
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $controller->show(new Request(), 'not-found');
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_question_number_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['search' => 1]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_question_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['search' => 'can']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_answer_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['search' => false]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_number_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['question_number' => 1]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['question_number' => 'like:1']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['question' => "Potions can restore a GF's HP."]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['question' => 'like:can']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_answer_column()
+    {
+        TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        $two = TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['answer' => true]));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $two->id,
+                    'sort_id' => $two->sort_id,
+                    'seed_test_id' => $two->seed_test_id,
+                    'question_number' => $two->question_number,
+                    'question' => $two->question,
+                    'answer' => $two->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $service = $this->app->make(TestQuestionService::class);
+        $transformer = new TestQuestionTransformer();
+        $controller = new TestQuestionController($service, $transformer);
+
+        $response = $controller->index(new Request(['answer' => 'like:f']));
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'seed_test_id' => $one->seed_test_id,
+                    'question_number' => $one->question_number,
+                    'question' => $one->question,
+                    'answer' => $one->answer,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'seed_test_id' => $three->seed_test_id,
+                    'question_number' => $three->question_number,
+                    'question' => $three->question,
+                    'answer' => $three->answer,
+                ],
+            ],
+        ], $response->getData(true));
+    }
+}

--- a/tests/Unit/Models/SeedTestTest.php
+++ b/tests/Unit/Models/SeedTestTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\SeedTest;
 use App\Traits\FiltersRecordsByFields;
+use App\Traits\LoadsRelationsThroughServices;
 use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
 use App\Traits\Uuids;
@@ -78,6 +79,7 @@ class SeedTestTest extends TestCase
         $visibleFields = [
             'id',
             'level',
+            'testQuestions',
         ];
 
         $this->assertEquals($visibleFields, $seedTest->getVisible());
@@ -104,7 +106,7 @@ class SeedTestTest extends TestCase
         $fields = $seedTest->getCasts();
 
         $expected = [
-            'id' => 'string',
+            'id'    => 'string',
             'level' => 'int',
         ];
 
@@ -133,6 +135,28 @@ class SeedTestTest extends TestCase
         ];
 
         $this->assertEquals($expected, $seedTest->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource()
+    {
+        $seedTest = new SeedTest();
+
+        $expected = [
+            'testQuestions',
+        ];
+
+        $this->assertEquals($expected, $seedTest->getAvailableIncludes());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource()
+    {
+        $seedTest = new SeedTest();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $seedTest->getDefaultIncludes());
     }
 
     /** @test */
@@ -186,6 +210,14 @@ class SeedTestTest extends TestCase
     {
         $this->assertTrue(in_array(
             FiltersRecordsByFields::class,
+            class_uses(SeedTest::class)
+        ));
+    }
+
+    public function it_loads_relations_through_services()
+    {
+        $this->assertTrue(in_array(
+            LoadsRelationsThroughServices::class,
             class_uses(SeedTest::class)
         ));
     }

--- a/tests/Unit/Models/TestQuestionTest.php
+++ b/tests/Unit/Models/TestQuestionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\TestQuestion;
 use App\Traits\FiltersRecordsByFields;
+use App\Traits\LoadsRelationsThroughServices;
 use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
 use App\Traits\Uuids;
@@ -82,6 +83,7 @@ class TestQuestionTest extends TestCase
             'question_number',
             'question',
             'answer',
+            'seedTest',
         ];
 
         $this->assertEquals($visibleFields, $testQuestion->getVisible());
@@ -148,6 +150,28 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource()
+    {
+        $testQuestion = new TestQuestion();
+
+        $expected = [
+            'seedTest',
+        ];
+
+        $this->assertEquals($expected, $testQuestion->getAvailableIncludes());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource()
+    {
+        $testQuestion = new TestQuestion();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $testQuestion->getDefaultIncludes());
+    }
+
+    /** @test */
     public function it_explicitly_defines_the_route_key_name()
     {
         $testQuestion = new TestQuestion();
@@ -198,6 +222,14 @@ class TestQuestionTest extends TestCase
     {
         $this->assertTrue(in_array(
             FiltersRecordsByFields::class,
+            class_uses(TestQuestion::class)
+        ));
+    }
+
+    public function it_loads_relations_through_services()
+    {
+        $this->assertTrue(in_array(
+            LoadsRelationsThroughServices::class,
             class_uses(TestQuestion::class)
         ));
     }

--- a/tests/Unit/Models/TestQuestionTest.php
+++ b/tests/Unit/Models/TestQuestionTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\TestQuestion;
+use App\Traits\FiltersRecordsByFields;
+use App\Traits\OrdersQueryResults;
+use App\Traits\Searchable;
+use App\Traits\Uuids;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase as TestCase;
+
+class TestQuestionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_explicitly_disables_incrementing_primary_keys()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertFalse($testQuestion->getIncrementing());
+    }
+
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals('test_questions', $testQuestion->getTable());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_column_explicitly()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals('id', $testQuestion->getKeyName());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals('string', $testQuestion->getKeyType());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals('sort_id', $testQuestion->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals('asc', $testQuestion->getOrderByDirection());
+    }
+
+    /** @test */
+    public function it_does_not_allow_properties_to_be_assigned_in_mass()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals([], $testQuestion->getFillable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $testQuestion = new TestQuestion();
+
+        $visibleFields = [
+            'id',
+            'sort_id',
+            'seed_test_id',
+            'question_number',
+            'question',
+            'answer',
+        ];
+
+        $this->assertEquals($visibleFields, $testQuestion->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    {
+        $testQuestion = new TestQuestion();
+
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        $this->assertEquals($hiddenFields, $testQuestion->getHidden());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_cast_type_for_each_field()
+    {
+        $testQuestion = new TestQuestion();
+        $fields = $testQuestion->getCasts();
+
+        $expected = [
+            'id'              => 'string',
+            'sort_id'         => 'integer',
+            'seed_test_id'    => 'string',
+            'question_number' => 'integer',
+            'question'        => 'string',
+            'answer'          => 'boolean',
+        ];
+
+        $this->assertEquals($expected, $fields);
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_searchable()
+    {
+        $testQuestion = new TestQuestion();
+
+        $expected = [
+            'question_number',
+            'question',
+            'answer',
+        ];
+
+        $this->assertEquals($expected, $testQuestion->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_filterable()
+    {
+        $testQuestion = new TestQuestion();
+
+        $expected = [
+            'question_number',
+            'question',
+            'answer',
+        ];
+
+        $this->assertEquals($expected, $testQuestion->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_route_key_name()
+    {
+        $testQuestion = new TestQuestion();
+
+        $this->assertEquals('id', $testQuestion->getRouteKeyName());
+    }
+
+    /** @test */
+    public function it_uses_uuids_for_the_primary_key()
+    {
+        $this->assertTrue(in_array(
+            Uuids::class,
+            class_uses(TestQuestion::class)
+        ));
+    }
+
+    /** @test */
+    public function it_will_not_allow_the_uuid_to_be_changed()
+    {
+        $testQuestion = TestQuestion::factory()->create();
+
+        $testQuestion->id = 'not-original-value';
+        $testQuestion->save();
+
+        $this->assertFalse($testQuestion->id === 'not-original-value');
+    }
+
+    /** @test */
+    public function it_can_order_query_results()
+    {
+        $this->assertTrue(in_array(
+            OrdersQueryResults::class,
+            class_uses(TestQuestion::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_search_functionality()
+    {
+        $this->assertTrue(in_array(
+            Searchable::class,
+            class_uses(TestQuestion::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_the_ability_to_filter_records_by_fields()
+    {
+        $this->assertTrue(in_array(
+            FiltersRecordsByFields::class,
+            class_uses(TestQuestion::class)
+        ));
+    }
+}

--- a/tests/Unit/Services/TestQuestionServiceTest.php
+++ b/tests/Unit/Services/TestQuestionServiceTest.php
@@ -1,0 +1,455 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\TestQuestion;
+use App\Services\TestQuestionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class TestQuestionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_test_questions()
+    {
+        $testQuestions = TestQuestion::factory()->count(10)->create();
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request());
+
+        $sortedTestQuestions = $testQuestions->sortBy([
+            [$model->getOrderByField(), $model->getOrderByDirection()],
+        ]);
+
+        $this->assertEquals($sortedTestQuestions->toArray(), $records);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_test_question_using_the_id_key()
+    {
+        $testQuestion = TestQuestion::factory()->create();
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->findOrFail($testQuestion->id, new Request());
+
+        $this->assertEquals($testQuestion->toArray(), $records);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $service->findOrFail('not-found', new Request());
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_question_number_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['search' => 1]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+            [
+                'id' => $three->id,
+                'sort_id' => $three->sort_id,
+                'seed_test_id' => $three->seed_test_id,
+                'question_number' => $three->question_number,
+                'question' => $three->question,
+                'answer' => $three->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_question_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['search' => 'can']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+            [
+                'id' => $three->id,
+                'sort_id' => $three->sort_id,
+                'seed_test_id' => $three->seed_test_id,
+                'question_number' => $three->question_number,
+                'question' => $three->question,
+                'answer' => $three->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_search_for_test_questions_via_the_answer_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['search' => false]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+            [
+                'id' => $three->id,
+                'sort_id' => $three->sort_id,
+                'seed_test_id' => $three->seed_test_id,
+                'question_number' => $three->question_number,
+                'question' => $three->question,
+                'answer' => $three->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_number_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['question_number' => 1]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['question_number' => 'like:1']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+            [
+                'id' => $three->id,
+                'sort_id' => $three->sort_id,
+                'seed_test_id' => $three->seed_test_id,
+                'question_number' => $three->question_number,
+                'question' => $three->question,
+                'answer' => $three->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_column()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['question' => "Potions can restore a GF's HP."]));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['question' => 'like:can']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+            [
+                'id' => $three->id,
+                'sort_id' => $three->sort_id,
+                'seed_test_id' => $three->seed_test_id,
+                'question_number' => $three->question_number,
+                'question' => $three->question,
+                'answer' => $three->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_answer_column()
+    {
+        TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        $two = TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['answer' => true]));
+
+        $this->assertEquals([
+            [
+                'id' => $two->id,
+                'sort_id' => $two->sort_id,
+                'seed_test_id' => $two->seed_test_id,
+                'question_number' => $two->question_number,
+                'question' => $two->question,
+                'answer' => $two->answer,
+            ],
+        ], $records);
+    }
+
+    /** @test */
+    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement()
+    {
+        $one = TestQuestion::factory()->create([
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+        ]);
+        TestQuestion::factory()->create([
+            'sort_id' => 2,
+            'question_number' => 5,
+            'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
+            'answer' => true,
+        ]);
+        $three = TestQuestion::factory()->create([
+            'sort_id' => 3,
+            'question_number' => 10,
+            'question' => 'You can stock up to 255 of each magic.',
+            'answer' => false,
+        ]);
+
+        $model = new TestQuestion();
+        $service = new TestQuestionService($model);
+
+        $records = $service->all(new Request(['answer' => 'like:f']));
+
+        $this->assertEquals([
+            [
+                'id' => $one->id,
+                'sort_id' => $one->sort_id,
+                'seed_test_id' => $one->seed_test_id,
+                'question_number' => $one->question_number,
+                'question' => $one->question,
+                'answer' => $one->answer,
+            ],
+            [
+                'id' => $three->id,
+                'sort_id' => $three->sort_id,
+                'seed_test_id' => $three->seed_test_id,
+                'question_number' => $three->question_number,
+                'question' => $three->question,
+                'answer' => $three->answer,
+            ],
+        ], $records);
+    }
+}

--- a/tests/Unit/Traits/LoadsRelationsThroughServicesTest.php
+++ b/tests/Unit/Traits/LoadsRelationsThroughServicesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Traits;
+
+use App\Models\SeedTest;
+use Tests\TestCase;
+
+class LoadsRelationsThroughServicesTest extends TestCase
+{
+    /** @test */
+    public function it_will_recursively_look_through_child_relations_to_validate_includes()
+    {
+        $seedTest = new SeedTest();
+
+        $includes = $seedTest->parseIncludes('test-questions.seed-test.not-expected');
+
+        // Since the include is not valid, it will drop the include entirely.
+        $this->assertEquals([], $includes);
+    }
+
+    /** @test */
+    public function it_will_validate_that_the_relation_exists_before_trying_to_retrieve_the_relation()
+    {
+        $seedTest = new SeedTest();
+
+        $includes = $seedTest->parseIncludes('test-questions.not-expected.test-questions');
+
+        // Since the include is not valid, it will drop the include entirely.
+        $this->assertEquals([], $includes);
+    }
+
+    /** @test */
+    public function it_will_only_load_two_levels_of_relations()
+    {
+        $seedTest = new SeedTest();
+
+        $expected = [
+            'testQuestions.seedTest.testQuestions',
+        ];
+
+        // Nesting three levels deep here.
+        $includes = $seedTest->parseIncludes('test-questions.seed-test.test-questions.seed-test');
+
+        // Will only return two levels deep.
+        $this->assertEquals($expected, $includes);
+    }
+}

--- a/tests/Unit/Transformers/V0/SeedTestTransformerTest.php
+++ b/tests/Unit/Transformers/V0/SeedTestTransformerTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Transformers\V0;
 
 use App\Http\Transformers\V0\SeedTestTransformer;
+use App\Http\Transformers\V0\TestQuestionTransformer;
 use App\Models\SeedTest;
+use App\Models\TestQuestion;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
@@ -18,7 +20,7 @@ class SeedTestTransformerTest extends TestCase
             'arbitrary' => 'data',
         ]);
 
-        $transformer = new SeedTestTransformer();
+        $transformer = $this->app->make(SeedTestTransformer::class);
 
         $transformedRecord = $transformer->transformRecord($seedTest->toArray());
 
@@ -37,7 +39,7 @@ class SeedTestTransformerTest extends TestCase
             ['id' => 'three']
         ));
 
-        $transformer = new SeedTestTransformer();
+        $transformer = $this->app->make(SeedTestTransformer::class);
 
         $transformedRecords = $transformer->transformCollection($seedTests->toArray());
 
@@ -55,5 +57,49 @@ class SeedTestTransformerTest extends TestCase
                 'level' => $seedTests[2]->level,
             ],
         ], $transformedRecords);
+    }
+
+    /** @test */
+    public function it_will_transform_the_test_questions_records_if_they_are_present()
+    {
+        $seedTest = SeedTest::factory()->make(['id' => 'some-uuid'])->toArray();
+        $testQuestions = TestQuestion::factory()->count(1)->make([
+            'id' => 'some-random-uuid',
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+            'arbitrary' => 'data',
+        ])->toArray();
+
+        // Manually append the Test Questions to the record since we're not using the database.
+        $seedTest['test_questions'] = $testQuestions;
+
+        $seedTestTransformer = $this->app->make(SeedTestTransformer::class);
+        $testQuestionTransformer = $this->app->make(TestQuestionTransformer::class);
+
+        $transformedSeedTest = $seedTestTransformer->transformRecord($seedTest);
+        $transformedTestQuestions = $testQuestionTransformer->transformCollection($testQuestions);
+
+        $this->assertArraySubset([
+            'test_questions' => $transformedTestQuestions,
+        ], $transformedSeedTest);
+    }
+
+    /** @test */
+    public function it_will_include_the_test_questions_key_in_the_event_no_records_are_returned_from_the_relation()
+    {
+        $seedTest = SeedTest::factory()->make(['id' => 'some-uuid'])->toArray();
+
+        // Manually append the Test Questions to the record since we're not using the database.
+        $seedTest['test_questions'] = null;
+
+        $seedTestTransformer = $this->app->make(SeedTestTransformer::class);
+
+        $transformedSeedTest = $seedTestTransformer->transformRecord($seedTest);
+
+        $this->assertArraySubset([
+            'test_questions' => null,
+        ], $transformedSeedTest);
     }
 }

--- a/tests/Unit/Transformers/V0/TestQuestionTransformerTest.php
+++ b/tests/Unit/Transformers/V0/TestQuestionTransformerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\V0\TestQuestionTransformer;
+use App\Models\TestQuestion;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Tests\TestCase;
+
+class TestQuestionTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_transform_a_single_record()
+    {
+        $testQuestion = TestQuestion::factory()->make([
+            'id' => 'some-random-uuid',
+            'sort_id' => 1,
+            'question_number' => 1,
+            'question' => "Potions can restore a GF's HP.",
+            'answer' => false,
+            'arbitrary' => 'data',
+        ]);
+
+        $transformer = new TestQuestionTransformer();
+
+        $transformedRecord = $transformer->transformRecord($testQuestion->toArray());
+
+        $this->assertEquals([
+            'id' => $testQuestion->id,
+            'sort_id' => $testQuestion->sort_id,
+            'seed_test_id' => $testQuestion->seed_test_id,
+            'question_number' => $testQuestion->question_number,
+            'question' => $testQuestion->question,
+            'answer' => $testQuestion->answer,
+        ], $transformedRecord);
+    }
+
+    /** @test */
+    public function it_will_transform_a_collection_of_records()
+    {
+        $testQuestions = TestQuestion::factory()->count(3)->make(new Sequence(
+            ['id' => 'one', 'sort_id' => 1],
+            ['id' => 'two', 'sort_id' => 2],
+            ['id' => 'three', 'sort_id' => 3]
+        ));
+
+        $transformer = new TestQuestionTransformer();
+
+        $transformedRecords = $transformer->transformCollection($testQuestions->toArray());
+
+        $this->assertEquals([
+            [
+                'id' => $testQuestions[0]->id,
+                'sort_id' => $testQuestions[0]->sort_id,
+                'seed_test_id' => $testQuestions[0]->seed_test_id,
+                'question_number' => $testQuestions[0]->question_number,
+                'question' => $testQuestions[0]->question,
+                'answer' => $testQuestions[0]->answer,
+            ],
+            [
+                'id' => $testQuestions[1]->id,
+                'sort_id' => $testQuestions[1]->sort_id,
+                'seed_test_id' => $testQuestions[1]->seed_test_id,
+                'question_number' => $testQuestions[1]->question_number,
+                'question' => $testQuestions[1]->question,
+                'answer' => $testQuestions[1]->answer,
+            ],
+            [
+                'id' => $testQuestions[2]->id,
+                'sort_id' => $testQuestions[2]->sort_id,
+                'seed_test_id' => $testQuestions[2]->seed_test_id,
+                'question_number' => $testQuestions[2]->question_number,
+                'question' => $testQuestions[2]->question,
+                'answer' => $testQuestions[2]->answer,
+            ],
+        ], $transformedRecords);
+    }
+}


### PR DESCRIPTION
The Test Question resource has been added!

This resource includes the same scaffolding and functionality as with the SeeD Rank & SeeD Test resources, and is available via the `/test-questions` endpoint.

Alongside this addition, the scaffolding for relationships has been added as well. The first relations to be made are between SeeD Tests and Test Questions. Various supporting changes have been made to accommodate this addition.

## Transformers

Transformers have been updated to include the ability to transform the included relation using the appropriate transformer. It was originally intended to include the dependent transformers within the constructor for each class. However, this cause problems with circular dependency, so it was moved to only use the dependent transformer when it was strictly necessary. This dependent transformer is created on demand and it stored so that it may be reused in the event the transformer needs to process a collection of records.

## Models

Models have been updated to include a `LoadsRelationsThroughServices` trait. This trait will look for properties defined on the model to parse and validate the requested relational includes. For example; a user will be able to load the Test Questions associated with a SeeD Test (or vice versa) by passing `include` parameter to the query string, followed by the desired relation to load along with the response;

```
/v0/seed-test?include=test-questions
```

This will load all of the Test Questions associated with the SeeD Test. Including nested relationships is also possible.

```
/v0/seed-test?include=test-questions.seed-test
```

This second example will load the SeeD Test that is associated with each Test Question. Albeit this is a bit redundant, the logic will expand to other adjacent resources.

It is important to note that this trait will only validate two levels deep starting from the base resource. This is to reduce the strain on the API and prevent the system from pulling a large amount of data when it would otherwise be unnecessary. For example;

```
/v0/seed-test?include=test-questions.seed-test.test-questions.seed-test
```

With this request, anything after the second `test-questions` relation will be dropped entirely.

## Traits

Some of the existing traits have also been refactored. The trait `OrdersQueryResults` has been refactored to include a global query scope (`App\Scopes\OrderQueryResults`) that will handle ordering all results returned from the database using the configuration that is defined on the model. This was necessary in order to easily handle sorting of the relations when they are loaded.

Alongside this, the `boot` method has been refactored for both `OrderQueryResults` and `Uuids` so that they do not conflict with one another. This simply involved changing the name so that Laravel will detect the traits properly.

## Misc

The `.php-cs-fixer.php` configuration has been updated to disable the `php_unit_method_casting` as it was causing conflicts with method names that were not associated with a test suite. Specifically, the `testQuestions()` relation method present on the `SeedTest` model. This fixer assumed that the method was for a unit test due to the beginning of the method name starting with `test`. There doesn't seem to be a workaround for this at the moment, so the rule has been disabled entirely.

## Unit Tests
Unit tests have naturally been updated to cover all use cases for features that have been implemented. Code coverage is currently sitting at 100%.