### PR TITLE
refactor: extract common logic to base model (API-79)

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\FiltersRecordsByFields;
+use App\Traits\LoadsRelationsThroughServices;
+use App\Traits\OrdersQueryResults;
+use App\Traits\Searchable;
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+class Model extends EloquentModel
+{
+    use FiltersRecordsByFields;
+    use LoadsRelationsThroughServices;
+    use OrdersQueryResults;
+    use Searchable;
+    use Uuids;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * The 'type' of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+}

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -2,27 +2,12 @@
 
 namespace App\Models;
 
-use App\Traits\FiltersRecordsByFields;
-use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
-use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
 class SeedRank extends Model
 {
-    use FiltersRecordsByFields;
     use HasFactory;
-    use OrdersQueryResults;
-    use Searchable;
-    use Uuids;
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * The table associated with the model.
@@ -30,20 +15,6 @@ class SeedRank extends Model
      * @var string
      */
     protected $table = 'seed_ranks';
-
-    /**
-     * The primary key for the model.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The 'type' of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
 
     /**
      * The default field used to order query results by.
@@ -60,13 +31,6 @@ class SeedRank extends Model
     protected $orderByDirection = 'asc';
 
     /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = [];
-
-    /**
      * The attributes that should be visible in serialization.
      *
      * @var array
@@ -75,17 +39,6 @@ class SeedRank extends Model
         'id',
         'rank',
         'salary',
-    ];
-
-    /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
-     */
-    protected $hidden = [
-        'created_at',
-        'updated_at',
-        'deleted_at',
     ];
 
     /**

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -19,14 +19,14 @@ class SeedRank extends Model
     /**
      * The default field used to order query results by.
      *
-     * @var array
+     * @var string
      */
     protected $orderByField = 'salary';
 
     /**
      * The default direction used to order query results by.
      *
-     * @var array
+     * @var string
      */
     protected $orderByDirection = 'asc';
 

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -20,14 +20,14 @@ class SeedTest extends Model
     /**
      * The default field used to order query results by.
      *
-     * @var array
+     * @var string
      */
     protected $orderByField = 'level';
 
     /**
      * The default direction used to order query results by.
      *
-     * @var array
+     * @var string
      */
     protected $orderByDirection = 'asc';
 

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -2,30 +2,13 @@
 
 namespace App\Models;
 
-use App\Traits\FiltersRecordsByFields;
-use App\Traits\LoadsRelationsThroughServices;
-use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
-use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SeedTest extends Model
 {
-    use FiltersRecordsByFields;
     use HasFactory;
-    use LoadsRelationsThroughServices;
-    use OrdersQueryResults;
-    use Searchable;
-    use Uuids;
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * The table associated with the model.
@@ -33,20 +16,6 @@ class SeedTest extends Model
      * @var string
      */
     protected $table = 'seed_tests';
-
-    /**
-     * The primary key for the model.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The 'type' of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
 
     /**
      * The default field used to order query results by.
@@ -63,13 +32,6 @@ class SeedTest extends Model
     protected $orderByDirection = 'asc';
 
     /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = [];
-
-    /**
      * The attributes that should be visible in serialization.
      *
      * @var array
@@ -81,24 +43,13 @@ class SeedTest extends Model
     ];
 
     /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
-     */
-    protected $hidden = [
-        'created_at',
-        'updated_at',
-        'deleted_at',
-    ];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array
      */
     protected $casts = [
         'id'    => 'string',
-        'level' => 'int',
+        'level' => 'integer',
     ];
 
     /**

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -20,14 +20,14 @@ class TestQuestion extends Model
     /**
      * The default field used to order query results by.
      *
-     * @var array
+     * @var string
      */
     protected $orderByField = 'sort_id';
 
     /**
      * The default direction used to order query results by.
      *
-     * @var array
+     * @var string
      */
     protected $orderByDirection = 'asc';
 

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -2,30 +2,13 @@
 
 namespace App\Models;
 
-use App\Traits\FiltersRecordsByFields;
-use App\Traits\LoadsRelationsThroughServices;
-use App\Traits\OrdersQueryResults;
 use App\Traits\Searchable;
-use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TestQuestion extends Model
 {
-    use FiltersRecordsByFields;
     use HasFactory;
-    use LoadsRelationsThroughServices;
-    use OrdersQueryResults;
-    use Searchable;
-    use Uuids;
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * The table associated with the model.
@@ -33,20 +16,6 @@ class TestQuestion extends Model
      * @var string
      */
     protected $table = 'test_questions';
-
-    /**
-     * The primary key for the model.
-     *
-     * @var string
-     */
-    protected $primaryKey = 'id';
-
-    /**
-     * The 'type' of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
 
     /**
      * The default field used to order query results by.
@@ -63,13 +32,6 @@ class TestQuestion extends Model
     protected $orderByDirection = 'asc';
 
     /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = [];
-
-    /**
      * The attributes that should be visible in serialization.
      *
      * @var array
@@ -82,17 +44,6 @@ class TestQuestion extends Model
         'question',
         'answer',
         'seedTest',
-    ];
-
-    /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
-     */
-    protected $hidden = [
-        'created_at',
-        'updated_at',
-        'deleted_at',
     ];
 
     /**

--- a/app/Traits/FiltersRecordsByFields.php
+++ b/app/Traits/FiltersRecordsByFields.php
@@ -11,9 +11,16 @@ trait FiltersRecordsByFields
      *
      * @return array
      */
+    protected $filterableFields = [];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
     public function getFilterableFields(): array
     {
-        return isset($this->filterableFields) ? $this->filterableFields : [];
+        return $this->filterableFields;
     }
 
     /**

--- a/app/Traits/LoadsRelationsThroughServices.php
+++ b/app/Traits/LoadsRelationsThroughServices.php
@@ -8,13 +8,27 @@ use Illuminate\Support\Str;
 trait LoadsRelationsThroughServices
 {
     /**
+     * The relations that are available to include with the resource.
+     *
+     * @var array
+     */
+    protected $availableIncludes = [];
+
+    /**
+     * The default relations to include with the resource.
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [];
+
+    /**
      * Get the relations that are available to include with the resource.
      *
      * @return array
      */
     public function getAvailableIncludes(): array
     {
-        return isset($this->availableIncludes) ? $this->availableIncludes : [];
+        return $this->availableIncludes;
     }
 
     /**
@@ -24,7 +38,7 @@ trait LoadsRelationsThroughServices
      */
     public function getDefaultIncludes(): array
     {
-        return isset($this->defaultIncludes) ? $this->defaultIncludes : [];
+        return $this->defaultIncludes;
     }
 
     /**

--- a/app/Traits/OrdersQueryResults.php
+++ b/app/Traits/OrdersQueryResults.php
@@ -7,13 +7,27 @@ use App\Scopes\OrderQueryResults;
 trait OrdersQueryResults
 {
     /**
+     * The default field used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByField = '';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
      * The default field which the records should be sorted by.
      *
      * @return string
      */
     public function getOrderByField(): string
     {
-        return isset($this->orderByField) ? $this->orderByField : $this->getKeyName;
+        return $this->orderByField ?: $this->getKeyName;
     }
 
     /**
@@ -23,7 +37,7 @@ trait OrdersQueryResults
      */
     public function getOrderByDirection(): string
     {
-        return isset($this->orderByDirection) ? $this->orderByDirection : 'asc';
+        return $this->orderByDirection;
     }
 
     /**

--- a/app/Traits/Searchable.php
+++ b/app/Traits/Searchable.php
@@ -7,13 +7,20 @@ use Illuminate\Database\Eloquent\Builder;
 trait Searchable
 {
     /**
+     * The fields that should be searchable.
+     *
+     * @var array
+     */
+    protected $searchableFields = [];
+
+    /**
      * Get the fields that should be searchable.
      *
      * @return array
      */
     public function getSearchableFields(): array
     {
-        return isset($this->searchableFields) ? $this->searchableFields : [];
+        return $this->searchableFields;
     }
 
     /**

--- a/tests/Unit/Models/ModelTest.php
+++ b/tests/Unit/Models/ModelTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Model;
+use App\Models\SeedRank;
+use App\Traits\FiltersRecordsByFields;
+use App\Traits\LoadsRelationsThroughServices;
+use App\Traits\OrdersQueryResults;
+use App\Traits\Searchable;
+use App\Traits\Uuids;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase as TestCase;
+
+class ModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_explicitly_disables_incrementing_primary_keys()
+    {
+        $model = new Model();
+
+        $this->assertFalse($model->getIncrementing());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_column_explicitly()
+    {
+        $model = new Model();
+
+        $this->assertEquals('id', $model->getKeyName());
+    }
+
+    /** @test */
+    public function it_sets_the_primary_key_type_to_string()
+    {
+        $model = new Model();
+
+        $this->assertEquals('string', $model->getKeyType());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    {
+        $model = new Model();
+
+        $this->assertEquals('asc', $model->getOrderByDirection());
+    }
+
+    /** @test */
+    public function it_does_not_allow_properties_to_be_assigned_in_mass()
+    {
+        $model = new Model();
+
+        $this->assertEquals([], $model->getFillable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    {
+        $model = new Model();
+
+        $hiddenFields = [
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        $this->assertEquals($hiddenFields, $model->getHidden());
+    }
+
+    /** @test */
+    public function it_uses_uuids_for_the_primary_key()
+    {
+        $this->assertTrue(in_array(
+            Uuids::class,
+            class_uses(Model::class)
+        ));
+    }
+
+    /** @test */
+    public function it_will_not_allow_the_uuid_to_be_changed()
+    {
+        $seedRank = SeedRank::factory()->create();
+
+        $seedRank->id = 'not-original-value';
+        $seedRank->save();
+
+        $this->assertFalse($seedRank->id === 'not-original-value');
+    }
+
+    /** @test */
+    public function it_can_order_query_results()
+    {
+        $this->assertTrue(in_array(
+            OrdersQueryResults::class,
+            class_uses(Model::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_search_functionality()
+    {
+        $this->assertTrue(in_array(
+            Searchable::class,
+            class_uses(Model::class)
+        ));
+    }
+
+    /** @test */
+    public function it_includes_the_ability_to_filter_records_by_fields()
+    {
+        $this->assertTrue(in_array(
+            FiltersRecordsByFields::class,
+            class_uses(Model::class)
+        ));
+    }
+
+    /** @test */
+    public function it_loads_relations_through_services()
+    {
+        $this->assertTrue(in_array(
+            LoadsRelationsThroughServices::class,
+            class_uses(Model::class)
+        ));
+    }
+}

--- a/tests/Unit/Models/SeedRankTest.php
+++ b/tests/Unit/Models/SeedRankTest.php
@@ -3,24 +3,12 @@
 namespace Tests\Unit\Models;
 
 use App\Models\SeedRank;
-use App\Traits\FiltersRecordsByFields;
-use App\Traits\OrdersQueryResults;
-use App\Traits\Searchable;
-use App\Traits\Uuids;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase as TestCase;
 
 class SeedRankTest extends TestCase
 {
     use RefreshDatabase;
-
-    /** @test */
-    public function it_explicitly_disables_incrementing_primary_keys()
-    {
-        $seedRank = new SeedRank();
-
-        $this->assertFalse($seedRank->getIncrementing());
-    }
 
     /** @test */
     public function it_uses_the_proper_database_table()
@@ -31,43 +19,11 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_the_primary_key_column_explicitly()
-    {
-        $seedRank = new SeedRank();
-
-        $this->assertEquals('id', $seedRank->getKeyName());
-    }
-
-    /** @test */
-    public function it_sets_the_primary_key_type_to_string()
-    {
-        $seedRank = new SeedRank();
-
-        $this->assertEquals('string', $seedRank->getKeyType());
-    }
-
-    /** @test */
     public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
     {
         $seedRank = new SeedRank();
 
         $this->assertEquals('salary', $seedRank->getOrderByField());
-    }
-
-    /** @test */
-    public function it_explicitly_defines_the_order_results_should_be_returned_by()
-    {
-        $seedRank = new SeedRank();
-
-        $this->assertEquals('asc', $seedRank->getOrderByDirection());
-    }
-
-    /** @test */
-    public function it_does_not_allow_properties_to_be_assigned_in_mass()
-    {
-        $seedRank = new SeedRank();
-
-        $this->assertEquals([], $seedRank->getFillable());
     }
 
     /** @test */
@@ -82,20 +38,6 @@ class SeedRankTest extends TestCase
         ];
 
         $this->assertEquals($visibleFields, $seedRank->getVisible());
-    }
-
-    /** @test */
-    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
-    {
-        $seedRank = new SeedRank();
-
-        $hiddenFields = [
-            'created_at',
-            'updated_at',
-            'deleted_at',
-        ];
-
-        $this->assertEquals($hiddenFields, $seedRank->getHidden());
     }
 
     /** @test */
@@ -145,52 +87,5 @@ class SeedRankTest extends TestCase
         $seedRank = new SeedRank();
 
         $this->assertEquals('rank', $seedRank->getRouteKeyName());
-    }
-
-    /** @test */
-    public function it_uses_uuids_for_the_primary_key()
-    {
-        $this->assertTrue(in_array(
-            Uuids::class,
-            class_uses(SeedRank::class)
-        ));
-    }
-
-    /** @test */
-    public function it_will_not_allow_the_uuid_to_be_changed()
-    {
-        $seedRank = SeedRank::factory()->create();
-
-        $seedRank->id = 'not-original-value';
-        $seedRank->save();
-
-        $this->assertFalse($seedRank->id === 'not-original-value');
-    }
-
-    /** @test */
-    public function it_can_order_query_results()
-    {
-        $this->assertTrue(in_array(
-            OrdersQueryResults::class,
-            class_uses(SeedRank::class)
-        ));
-    }
-
-    /** @test */
-    public function it_includes_search_functionality()
-    {
-        $this->assertTrue(in_array(
-            Searchable::class,
-            class_uses(SeedRank::class)
-        ));
-    }
-
-    /** @test */
-    public function it_includes_the_ability_to_filter_records_by_fields()
-    {
-        $this->assertTrue(in_array(
-            FiltersRecordsByFields::class,
-            class_uses(SeedRank::class)
-        ));
     }
 }

--- a/tests/Unit/Models/SeedTestTest.php
+++ b/tests/Unit/Models/SeedTestTest.php
@@ -3,25 +3,12 @@
 namespace Tests\Unit\Models;
 
 use App\Models\SeedTest;
-use App\Traits\FiltersRecordsByFields;
-use App\Traits\LoadsRelationsThroughServices;
-use App\Traits\OrdersQueryResults;
-use App\Traits\Searchable;
-use App\Traits\Uuids;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase as TestCase;
 
 class SeedTestTest extends TestCase
 {
     use RefreshDatabase;
-
-    /** @test */
-    public function it_explicitly_disables_incrementing_primary_keys()
-    {
-        $seedTest = new SeedTest();
-
-        $this->assertFalse($seedTest->getIncrementing());
-    }
 
     /** @test */
     public function it_uses_the_proper_database_table()
@@ -32,43 +19,11 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_the_primary_key_column_explicitly()
-    {
-        $seedTest = new SeedTest();
-
-        $this->assertEquals('id', $seedTest->getKeyName());
-    }
-
-    /** @test */
-    public function it_sets_the_primary_key_type_to_string()
-    {
-        $seedTest = new SeedTest();
-
-        $this->assertEquals('string', $seedTest->getKeyType());
-    }
-
-    /** @test */
     public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
     {
         $seedTest = new SeedTest();
 
         $this->assertEquals('level', $seedTest->getOrderByField());
-    }
-
-    /** @test */
-    public function it_explicitly_defines_the_order_results_should_be_returned_by()
-    {
-        $seedTest = new SeedTest();
-
-        $this->assertEquals('asc', $seedTest->getOrderByDirection());
-    }
-
-    /** @test */
-    public function it_does_not_allow_properties_to_be_assigned_in_mass()
-    {
-        $seedTest = new SeedTest();
-
-        $this->assertEquals([], $seedTest->getFillable());
     }
 
     /** @test */
@@ -86,20 +41,6 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
-    {
-        $seedTest = new SeedTest();
-
-        $hiddenFields = [
-            'created_at',
-            'updated_at',
-            'deleted_at',
-        ];
-
-        $this->assertEquals($hiddenFields, $seedTest->getHidden());
-    }
-
-    /** @test */
     public function it_explicitly_defines_the_cast_type_for_each_field()
     {
         $seedTest = new SeedTest();
@@ -107,7 +48,7 @@ class SeedTestTest extends TestCase
 
         $expected = [
             'id'    => 'string',
-            'level' => 'int',
+            'level' => 'integer',
         ];
 
         $this->assertEquals($expected, $fields);
@@ -165,60 +106,5 @@ class SeedTestTest extends TestCase
         $seedTest = new SeedTest();
 
         $this->assertEquals('level', $seedTest->getRouteKeyName());
-    }
-
-    /** @test */
-    public function it_uses_uuids_for_the_primary_key()
-    {
-        $this->assertTrue(in_array(
-            Uuids::class,
-            class_uses(SeedTest::class)
-        ));
-    }
-
-    /** @test */
-    public function it_will_not_allow_the_uuid_to_be_changed()
-    {
-        $seedTest = SeedTest::factory()->create();
-
-        $seedTest->id = 'not-original-value';
-        $seedTest->save();
-
-        $this->assertFalse($seedTest->id === 'not-original-value');
-    }
-
-    /** @test */
-    public function it_can_order_query_results()
-    {
-        $this->assertTrue(in_array(
-            OrdersQueryResults::class,
-            class_uses(SeedTest::class)
-        ));
-    }
-
-    /** @test */
-    public function it_includes_search_functionality()
-    {
-        $this->assertTrue(in_array(
-            Searchable::class,
-            class_uses(SeedTest::class)
-        ));
-    }
-
-    /** @test */
-    public function it_includes_the_ability_to_filter_records_by_fields()
-    {
-        $this->assertTrue(in_array(
-            FiltersRecordsByFields::class,
-            class_uses(SeedTest::class)
-        ));
-    }
-
-    public function it_loads_relations_through_services()
-    {
-        $this->assertTrue(in_array(
-            LoadsRelationsThroughServices::class,
-            class_uses(SeedTest::class)
-        ));
     }
 }

--- a/tests/Unit/Models/TestQuestionTest.php
+++ b/tests/Unit/Models/TestQuestionTest.php
@@ -3,25 +3,12 @@
 namespace Tests\Unit\Models;
 
 use App\Models\TestQuestion;
-use App\Traits\FiltersRecordsByFields;
-use App\Traits\LoadsRelationsThroughServices;
-use App\Traits\OrdersQueryResults;
-use App\Traits\Searchable;
-use App\Traits\Uuids;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase as TestCase;
 
 class TestQuestionTest extends TestCase
 {
     use RefreshDatabase;
-
-    /** @test */
-    public function it_explicitly_disables_incrementing_primary_keys()
-    {
-        $testQuestion = new TestQuestion();
-
-        $this->assertFalse($testQuestion->getIncrementing());
-    }
 
     /** @test */
     public function it_uses_the_proper_database_table()
@@ -32,43 +19,11 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_the_primary_key_column_explicitly()
-    {
-        $testQuestion = new TestQuestion();
-
-        $this->assertEquals('id', $testQuestion->getKeyName());
-    }
-
-    /** @test */
-    public function it_sets_the_primary_key_type_to_string()
-    {
-        $testQuestion = new TestQuestion();
-
-        $this->assertEquals('string', $testQuestion->getKeyType());
-    }
-
-    /** @test */
     public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
     {
         $testQuestion = new TestQuestion();
 
         $this->assertEquals('sort_id', $testQuestion->getOrderByField());
-    }
-
-    /** @test */
-    public function it_explicitly_defines_the_order_results_should_be_returned_by()
-    {
-        $testQuestion = new TestQuestion();
-
-        $this->assertEquals('asc', $testQuestion->getOrderByDirection());
-    }
-
-    /** @test */
-    public function it_does_not_allow_properties_to_be_assigned_in_mass()
-    {
-        $testQuestion = new TestQuestion();
-
-        $this->assertEquals([], $testQuestion->getFillable());
     }
 
     /** @test */
@@ -87,20 +42,6 @@ class TestQuestionTest extends TestCase
         ];
 
         $this->assertEquals($visibleFields, $testQuestion->getVisible());
-    }
-
-    /** @test */
-    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
-    {
-        $testQuestion = new TestQuestion();
-
-        $hiddenFields = [
-            'created_at',
-            'updated_at',
-            'deleted_at',
-        ];
-
-        $this->assertEquals($hiddenFields, $testQuestion->getHidden());
     }
 
     /** @test */
@@ -177,60 +118,5 @@ class TestQuestionTest extends TestCase
         $testQuestion = new TestQuestion();
 
         $this->assertEquals('id', $testQuestion->getRouteKeyName());
-    }
-
-    /** @test */
-    public function it_uses_uuids_for_the_primary_key()
-    {
-        $this->assertTrue(in_array(
-            Uuids::class,
-            class_uses(TestQuestion::class)
-        ));
-    }
-
-    /** @test */
-    public function it_will_not_allow_the_uuid_to_be_changed()
-    {
-        $testQuestion = TestQuestion::factory()->create();
-
-        $testQuestion->id = 'not-original-value';
-        $testQuestion->save();
-
-        $this->assertFalse($testQuestion->id === 'not-original-value');
-    }
-
-    /** @test */
-    public function it_can_order_query_results()
-    {
-        $this->assertTrue(in_array(
-            OrdersQueryResults::class,
-            class_uses(TestQuestion::class)
-        ));
-    }
-
-    /** @test */
-    public function it_includes_search_functionality()
-    {
-        $this->assertTrue(in_array(
-            Searchable::class,
-            class_uses(TestQuestion::class)
-        ));
-    }
-
-    /** @test */
-    public function it_includes_the_ability_to_filter_records_by_fields()
-    {
-        $this->assertTrue(in_array(
-            FiltersRecordsByFields::class,
-            class_uses(TestQuestion::class)
-        ));
-    }
-
-    public function it_loads_relations_through_services()
-    {
-        $this->assertTrue(in_array(
-            LoadsRelationsThroughServices::class,
-            class_uses(TestQuestion::class)
-        ));
     }
 }


### PR DESCRIPTION
This will introduce a base `App\Models\Model` class for all other models to extend. This base class includes common functionality and configurations used throughout each model in an attempt to keep the codebase relatively clean and stable. As an addition, various traits have been updated to include their local properties within the trait itself. This was not possible previously as PHP would not allow traits to be defined on both the trait, as well as the class which implements said trait. Properties of traits may only be defined on classes that _inherit_ another class which uses a trait.

The base model includes the following traits out of the box;

* `App\Traits\FiltersRecordsByFields`
* `App\Traits\LoadsRelationsThroughServices`
* `App\Traits\OrdersQueryResults`
* `App\Traits\Searchable`
* `App\Traits\Uuids`

Tests have been updated to follow suit and code coverage remains at 100%.