### PR TITLE
feat: add inbound request analytics (API-53)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -31,6 +31,7 @@ class Kernel extends HttpKernel
     protected $middlewareGroups = [
         'api' => [
             'throttle:api',
+            'request.capture',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];
@@ -52,5 +53,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'request.capture' => \App\Http\Middleware\CaptureInboundRequest::class,
     ];
 }

--- a/app/Http/Middleware/CaptureInboundRequest.php
+++ b/app/Http/Middleware/CaptureInboundRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Webpatser\Uuid\Uuid;
+
+class CaptureInboundRequest
+{
+    protected $startTime = 0;
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param Request $request The HTTP request from the client
+     * @param Closure $next    The next middleware in the chain
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $this->startTime = microtime(true);
+
+        return $next($request);
+    }
+
+    /**
+     * Handle tasks after the response has been sent to the browser.
+     *
+     * @param Request      $request  The HTTP request from the client
+     * @param JsonResponse $response The response sent back to the client
+     *
+     * @return void
+     */
+    public function terminate(Request $request, JsonResponse $response)
+    {
+        $endTime = microtime(true);
+        $timeInMilliseconds = number_format($endTime - $this->startTime, 3) * 1000;
+
+        DB::table('inbound_requests')->insert([
+            'id' => Uuid::generate(4),
+            'ip_address' => $request->getClientIp(),
+            'user_agent' => $request->userAgent(),
+            'api_version' => $request->route() ? $request->route()->getPrefix() : null,
+            'path' => $request->getPathInfo(),
+            'query_string' => $request->getQueryString(),
+            'full_path' => $request->getRequestUri(),
+            'full_uri' => $request->getUri(),
+            'headers' => json_encode($request->headers->all()),
+            'status_code' => $response->getStatusCode(),
+            'duration' => $timeInMilliseconds,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+}

--- a/app/Http/Middleware/CaptureInboundRequest.php
+++ b/app/Http/Middleware/CaptureInboundRequest.php
@@ -11,6 +11,11 @@ use Webpatser\Uuid\Uuid;
 
 class CaptureInboundRequest
 {
+    /**
+     * The time at which the request was first processed.
+     *
+     * @var int
+     */
     protected $startTime = 0;
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Http\Middleware\CaptureInboundRequest;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -27,6 +28,8 @@ class AppServiceProvider extends ServiceProvider
             \App\Contracts\Services\TestQuestionService::class,
             \App\Services\TestQuestionService::class
         );
+
+        $this->app->singleton(CaptureInboundRequest::class);
     }
 
     /**

--- a/database/migrations/2021_09_18_034118_create_inbound_requests_table.php
+++ b/database/migrations/2021_09_18_034118_create_inbound_requests_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInboundRequestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inbound_requests', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('ip_address')->nullable();
+            $table->string('user_agent')->nullable();
+            $table->string('api_version')->nullable();
+            $table->string('path')->nullable();
+            $table->string('query_string')->nullable();
+            $table->string('full_path')->nullable();
+            $table->string('full_uri')->nullable();
+            $table->json('headers')->nullable();
+            $table->string('status_code')->nullable();
+            $table->integer('duration')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inbound_requests');
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
 use App\Http\Controllers\V0\TestQuestionController;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/')->uses([HealthCheckController::class, 'status']);
@@ -16,3 +17,30 @@ Route::get('/seed-tests/{test}')->uses([SeedTestController::class, 'show']);
 
 Route::get('/test-questions/')->uses([TestQuestionController::class, 'index']);
 Route::get('/test-questions/{id}')->uses([TestQuestionController::class, 'show']);
+
+Route::get('/exception', function () {
+    throw new \Exception('Exception');
+});
+
+Route::get('/request', function (Request $request) {
+    $arr = [];
+
+    $ip = $request->getClientIp();
+    $userAgent = $request->userAgent();
+    $apiVersion = $request->route()->getPrefix();
+    $path = $request->getPathInfo();
+    $queryString = $request->getQueryString();
+    $fullPath = $request->getRequestUri();
+    $fullUri = $request->getUri();
+    $headers = $request->headers->all();
+    $statusCode = $request->getStatusCode();
+
+    dd($arr);
+
+    // Ip
+    // Headers
+    // API Version
+    // Endpoint
+    // Query String
+    // Success?
+});

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -4,7 +4,6 @@ use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
 use App\Http\Controllers\V0\TestQuestionController;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/')->uses([HealthCheckController::class, 'status']);
@@ -17,30 +16,3 @@ Route::get('/seed-tests/{test}')->uses([SeedTestController::class, 'show']);
 
 Route::get('/test-questions/')->uses([TestQuestionController::class, 'index']);
 Route::get('/test-questions/{id}')->uses([TestQuestionController::class, 'show']);
-
-Route::get('/exception', function () {
-    throw new \Exception('Exception');
-});
-
-Route::get('/request', function (Request $request) {
-    $arr = [];
-
-    $ip = $request->getClientIp();
-    $userAgent = $request->userAgent();
-    $apiVersion = $request->route()->getPrefix();
-    $path = $request->getPathInfo();
-    $queryString = $request->getQueryString();
-    $fullPath = $request->getRequestUri();
-    $fullUri = $request->getUri();
-    $headers = $request->headers->all();
-    $statusCode = $request->getStatusCode();
-
-    dd($arr);
-
-    // Ip
-    // Headers
-    // API Version
-    // Endpoint
-    // Query String
-    // Success?
-});

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -9,6 +9,8 @@ class HealthCheckEndpointTest extends TestCase
     /** @test */
     public function it_can_check_the_server_status()
     {
+        $this->withoutMiddleware();
+
         $baseUrl = config('app.url');
         $currentApiVersion = config('app.current_api_version');
 
@@ -23,6 +25,8 @@ class HealthCheckEndpointTest extends TestCase
                 'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
                 'resources' => [
                     'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+                    'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
+                    'test_questions' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
                 ],
             ],
         ]);

--- a/tests/Feature/Middleware/CaptureInboundRequestTest.php
+++ b/tests/Feature/Middleware/CaptureInboundRequestTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Middleware;
+
+use App\Contracts\Services\SeedRankService;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CaptureInboundRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_record_successful_requests()
+    {
+        $this->get('/v0/seed-ranks');
+
+        $this->assertDatabaseCount('inbound_requests', 1);
+    }
+
+    /** @test */
+    public function it_will_record_unsuccessful_requests()
+    {
+        $mockedService = $this->mock(SeedRankService::class, function ($mock) {
+            $mock->shouldReceive('all')->andThrow(new Exception('Something'));
+        });
+        $this->app->instance(SeedRankService::class, $mockedService);
+
+        $this->get('/v0/seed-ranks');
+
+        $this->assertDatabaseCount('inbound_requests', 1);
+    }
+
+    /** @test */
+    public function it_will_not_record_404_requests()
+    {
+        $this->get('/invalid-endpoint');
+
+        $this->assertDatabaseCount('inbound_requests', 0);
+    }
+}

--- a/tests/Feature/Middleware/CaptureInboundRequestTest.php
+++ b/tests/Feature/Middleware/CaptureInboundRequestTest.php
@@ -12,7 +12,7 @@ class CaptureInboundRequestTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_record_successful_requests()
+    public function it_will_capture_successful_requests()
     {
         $this->get('/v0/seed-ranks');
 
@@ -20,7 +20,7 @@ class CaptureInboundRequestTest extends TestCase
     }
 
     /** @test */
-    public function it_will_record_unsuccessful_requests()
+    public function it_will_capture_unsuccessful_requests()
     {
         $mockedService = $this->mock(SeedRankService::class, function ($mock) {
             $mock->shouldReceive('all')->andThrow(new Exception('Something'));
@@ -33,7 +33,7 @@ class CaptureInboundRequestTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_record_404_requests()
+    public function it_will_not_capture_404_requests()
     {
         $this->get('/invalid-endpoint');
 

--- a/tests/Unit/Middleware/CaptureInboundRequestTest.php
+++ b/tests/Unit/Middleware/CaptureInboundRequestTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Middleware;
+
+use App\Http\Middleware\CaptureInboundRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class CaptureInboundRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_record_successful_requests()
+    {
+        $request = new Request();
+        $response = new JsonResponse([], 200);
+        $middleware = new CaptureInboundRequest();
+
+        $middleware->handle($request, function () {});
+        $middleware->terminate($request, $response);
+
+        /*
+         * The 'duration' field will also be present within the request.
+         * However, we can't easily test for this.
+         */
+        $this->assertDatabaseCount('inbound_requests', 1);
+        $this->assertDatabaseHas('inbound_requests', [
+            'ip_address' => $request->getClientIp(),
+            'user_agent' => $request->userAgent(),
+            'api_version' => $request->route() ? $request->route()->getPrefix() : null,
+            'path' => $request->getPathInfo(),
+            'query_string' => $request->getQueryString(),
+            'full_path' => $request->getRequestUri(),
+            'full_uri' => $request->getUri(),
+            'headers' => json_encode($request->headers->all()),
+            'status_code' => $response->getStatusCode(),
+        ]);
+    }
+
+    /** @test */
+    public function it_will_record_unsuccessful_requests()
+    {
+        $request = new Request();
+        $response = new JsonResponse([], 500);
+        $middleware = new CaptureInboundRequest();
+
+        $middleware->handle($request, function () {});
+        $middleware->terminate($request, $response);
+
+        /*
+         * The 'duration' field will also be present within the request.
+         * However, we can't easily test for this.
+         */
+        $this->assertDatabaseCount('inbound_requests', 1);
+        $this->assertDatabaseHas('inbound_requests', [
+            'ip_address' => $request->getClientIp(),
+            'user_agent' => $request->userAgent(),
+            'api_version' => $request->route() ? $request->route()->getPrefix() : null,
+            'path' => $request->getPathInfo(),
+            'query_string' => $request->getQueryString(),
+            'full_path' => $request->getRequestUri(),
+            'full_uri' => $request->getUri(),
+            'headers' => json_encode($request->headers->all()),
+            'status_code' => $response->getStatusCode(),
+        ]);
+    }
+}

--- a/tests/Unit/Middleware/CaptureInboundRequestTest.php
+++ b/tests/Unit/Middleware/CaptureInboundRequestTest.php
@@ -13,7 +13,7 @@ class CaptureInboundRequestTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_record_successful_requests()
+    public function it_will_capture_successful_requests()
     {
         $request = new Request();
         $response = new JsonResponse([], 200);
@@ -41,7 +41,7 @@ class CaptureInboundRequestTest extends TestCase
     }
 
     /** @test */
-    public function it_will_record_unsuccessful_requests()
+    public function it_will_capture_unsuccessful_requests()
     {
         $request = new Request();
         $response = new JsonResponse([], 500);


### PR DESCRIPTION
This introduces the ability to capture inbound requests which will be used for analytics throughout the application's lifetime. With this being the only use case, I've left the implementation fairly barebones and have excluded the scaffolding for models and such. Instead, we're simply creating a database table and dropping the request data directly into the table as part of the `CaptureInboundRequest` middleware.

The `CaptureInboundRequest` middleware is mapped to the API route group, and will activate _after_ the throttle middleware has processed the request. This will unfortunately skew response time reporting slightly (~5-10ms during testing), but will also result in better stability in the long run as throttled requests won't be clogging up the system.