### PR TITLE
fix: remove throttle middleware from status endpoint (API-80)

### DIFF
--- a/routes/v0.php
+++ b/routes/v0.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\V0\SeedTestController;
 use App\Http\Controllers\V0\TestQuestionController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/')->uses([HealthCheckController::class, 'status']);
+Route::get('/')->uses([HealthCheckController::class, 'status'])->withoutMiddleware(['throttle:api']);
 
 Route::get('/seed-ranks/')->uses([SeedRankController::class, 'index']);
 Route::get('/seed-ranks/{rank}')->uses([SeedRankController::class, 'show']);


### PR DESCRIPTION
Kubernetes will probe the application container periodically to ensure that the container is stable. If the probe returns a non-successful status code, Kubernetes will kill the container and spin up a new one. It was discovered that Kubernetes had been periodically restarting the VIIIDB-API container due to throttling limits on the status endpoint. This will simply remove the throttle limitations on the status endpoint alone so that the probes will not restart the container under false conditions.