### PR TITLE
fix: remove request analytics from status endpoint (API-81)

### DIFF
--- a/routes/v0.php
+++ b/routes/v0.php
@@ -6,7 +6,10 @@ use App\Http\Controllers\V0\SeedTestController;
 use App\Http\Controllers\V0\TestQuestionController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/')->uses([HealthCheckController::class, 'status'])->withoutMiddleware(['throttle:api']);
+Route::get('/')->uses([HealthCheckController::class, 'status'])->withoutMiddleware([
+    'throttle:api',
+    'request.capture',
+]);
 
 Route::get('/seed-ranks/')->uses([SeedRankController::class, 'index']);
 Route::get('/seed-ranks/{rank}')->uses([SeedRankController::class, 'show']);


### PR DESCRIPTION
This was overlooked previously, but including the `CaptureInboundRequest` middleware on the status endpoint will also capture all of the probe traffic from Kubernetes. This is undesirable. The middleware can simply be removed from this endpoint as tracking the traffic here is of no concern.