### PR TITLE
feat: add status effect resource (API-12)

### DIFF
--- a/app/Contracts/Services/StatusEffectService.php
+++ b/app/Contracts/Services/StatusEffectService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Contracts\Services;
+
+interface StatusEffectService extends ModelService
+{
+}

--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -26,6 +26,7 @@ class HealthCheckController extends Controller
                 'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
                 'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
                 'test_questions' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
+                'status_effects' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
             ],
         ]);
     }

--- a/app/Http/Controllers/V0/StatusEffectController.php
+++ b/app/Http/Controllers/V0/StatusEffectController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\StatusEffectService;
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\V0\StatusEffectTransformer;
+use App\Traits\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class StatusEffectController extends Controller
+{
+    use ApiResponse;
+
+    /**
+     * Instance of the StatusEffectService.
+     *
+     * @var StatusEffectService
+     */
+    protected $statusEffectService;
+
+    /**
+     * Instance of the StatusEffectTransformer.
+     *
+     * @var StatusEffectTransformer
+     */
+    protected $statusEffectTransformer;
+
+    /**
+     * Create a new StatusEffectController instance.
+     *
+     * @param StatusEffectService     $statusEffectService     The Service that will process the request
+     * @param StatusEffectTransformer $statusEffectTransformer The Transformer that will standardize the response
+     */
+    public function __construct(StatusEffectService $statusEffectService, StatusEffectTransformer $statusEffectTransformer)
+    {
+        $this->statusEffectService = $statusEffectService;
+        $this->statusEffectTransformer = $statusEffectTransformer;
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $records = $this->statusEffectService->all($request);
+
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->statusEffectTransformer->transformCollection($records)
+        );
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param Request $request        The HTTP request from the client
+     * @param string  $statusEffectId The ID of the requested StatusEffect
+     *
+     * @return JsonResponse
+     */
+    public function show(Request $request, string $statusEffectId): JsonResponse
+    {
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->statusEffectTransformer->transformRecord(
+                $this->statusEffectService->findOrFail($statusEffectId, $request)
+            )
+        );
+    }
+}

--- a/app/Http/Transformers/V0/StatusEffectTransformer.php
+++ b/app/Http/Transformers/V0/StatusEffectTransformer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Transformers\V0;
+
+use App\Contracts\Transformers\RecordTransformer;
+
+class StatusEffectTransformer implements RecordTransformer
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array $record The record to be transformed
+     *
+     * @return array
+     */
+    public function transformRecord(array $record): array
+    {
+        return [
+            'id' => $record['id'],
+            'name' => $record['name'],
+            'type' => $record['type'],
+            'description' => $record['description'],
+        ];
+    }
+
+    /**
+     * Transforms a collection of records to standardize the output.
+     *
+     * @param array $collection The collection of records to be transformed
+     *
+     * @return array
+     */
+    public function transformCollection(array $collection): array
+    {
+        $data = [];
+
+        foreach ($collection as $record) {
+            $data[] = $this->transformRecord($record);
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Traits\Searchable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 

--- a/app/Models/StatusEffect.php
+++ b/app/Models/StatusEffect.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class SeedRank extends Model
+class StatusEffect extends Model
 {
     use HasFactory;
 
@@ -13,14 +13,14 @@ class SeedRank extends Model
      *
      * @var string
      */
-    protected $table = 'seed_ranks';
+    protected $table = 'status_effects';
 
     /**
      * The default field used to order query results by.
      *
      * @var string
      */
-    protected $orderByField = 'salary';
+    protected $orderByField = 'name';
 
     /**
      * The default direction used to order query results by.
@@ -36,8 +36,9 @@ class SeedRank extends Model
      */
     protected $visible = [
         'id',
-        'rank',
-        'salary',
+        'name',
+        'type',
+        'description',
     ];
 
     /**
@@ -46,9 +47,10 @@ class SeedRank extends Model
      * @var array
      */
     protected $casts = [
-        'id'     => 'string',
-        'rank'   => 'string',
-        'salary' => 'integer',
+        'id'          => 'string',
+        'name'        => 'string',
+        'type'        => 'string',
+        'description' => 'string',
     ];
 
     /**
@@ -57,8 +59,9 @@ class SeedRank extends Model
      * @var array
      */
     protected $searchableFields = [
-        'rank',
-        'salary',
+        'name',
+        'type',
+        'description',
     ];
 
     /**
@@ -67,8 +70,9 @@ class SeedRank extends Model
      * @return array
      */
     protected $filterableFields = [
-        'rank',
-        'salary',
+        'name',
+        'type',
+        'description',
     ];
 
     /*
@@ -78,6 +82,6 @@ class SeedRank extends Model
      */
     public function getRouteKeyName(): string
     {
-        return 'rank';
+        return 'name';
     }
 }

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Traits\Searchable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,6 +29,11 @@ class AppServiceProvider extends ServiceProvider
             \App\Services\TestQuestionService::class
         );
 
+        $this->app->bind(
+            \App\Contracts\Services\StatusEffectService::class,
+            \App\Services\StatusEffectService::class
+        );
+
         $this->app->singleton(CaptureInboundRequest::class);
     }
 

--- a/app/Services/StatusEffectService.php
+++ b/app/Services/StatusEffectService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Services\StatusEffectService as StatusEffectServiceContract;
+use App\Models\StatusEffect;
+
+class StatusEffectService extends ModelService implements StatusEffectServiceContract
+{
+    /**
+     * Create a new StatusEffectService instance.
+     *
+     * @param StatusEffect $model The instance of the model to use for the service
+     */
+    public function __construct(StatusEffect $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/database/factories/StatusEffectFactory.php
+++ b/database/factories/StatusEffectFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\StatusEffect;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class StatusEffectFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = StatusEffect::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word,
+            'type' => $this->faker->word,
+            'description' => $this->faker->paragraph,
+        ];
+    }
+}

--- a/database/migrations/2021_09_22_013217_create_status_effects_table.php
+++ b/database/migrations/2021_09_22_013217_create_status_effects_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStatusEffectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('status_effects', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('type');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('status_effects');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,5 +16,6 @@ class DatabaseSeeder extends Seeder
         $this->call(SeedRanksTableSeeder::class);
         $this->call(SeedTestsTableSeeder::class);
         $this->call(TestQuestionsTableSeeder::class);
+        $this->call(StatusEffectsTableSeeder::class);
     }
 }

--- a/database/seeders/StatusEffectsTableSeeder.php
+++ b/database/seeders/StatusEffectsTableSeeder.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\StatusEffect;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class StatusEffectsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $statusEffects = $this->getStatusEffects();
+
+        foreach ($statusEffects as $key => $value) {
+            $statusEffects[$key]['id'] = Uuid::generate(4);
+            $statusEffects[$key]['created_at'] = Carbon::now();
+            $statusEffects[$key]['updated_at'] = Carbon::now();
+        }
+
+        $statusEffect = new StatusEffect();
+
+        $statusEffect->insert($statusEffects);
+    }
+
+    /**
+     * The Status Effects to be inserted into the database.
+     *
+     * @return array
+     */
+    protected function getStatusEffects(): array
+    {
+        return [
+            [
+                'name' => 'death',
+                'type' => 'harmful',
+                'description' => "The Death status reduces the target's HP to 0. Monsters afflicted with death are removed from combat. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'poison',
+                'type' => 'harmful',
+                'description' => "The Poison status deals damage to the target after each action they take. The damage is around 1/20th of the target's maximum HP each tick. This effect does not wear off on its own.",
+            ],
+            [
+                'name' => 'petrify',
+                'type' => 'harmful',
+                'description' => 'The Petrify status will render the target unable to perform any actions. Enemies will be considered as removed from combat. If all targets are petrified (either enemies or players), the battle will end. This effect does not wear off on its own.',
+            ],
+            [
+                'name' => 'darkness',
+                'type' => 'harmful',
+                'description' => 'The Darkness status will reduce the targets hit by 75%. Characters that have 255% hit will be unaffected by this status. This effect does not wear off on its own.',
+            ],
+            [
+                'name' => 'silence',
+                'type' => 'harmful',
+                'description' => 'The Silence status will render targets unable to use the magic, GF, and draw commands. This effect does not wear off on its own.',
+            ],
+            [
+                'name' => 'berserk',
+                'type' => 'harmful',
+                'description' => 'The Berserk status will force the target to perform basic attacks on a random target during each turn. Attacks are boosted by 50% of their normal value. This effect does not wear off on its own.',
+            ],
+            [
+                'name' => 'zombie',
+                'type' => 'harmful',
+                'description' => 'The Zombie status causes the target to act as if undead. This effect does not wear off on its own.',
+            ],
+            [
+                'name' => 'sleep',
+                'type' => 'harmful',
+                'description' => 'The Sleep status will render targets unable to perform an actions. Receiving physical damage will remove the effect. This effect will wear off automatically over time.',
+            ],
+            [
+                'name' => 'haste',
+                'type' => 'beneficial',
+                'description' => 'The Haste status increases the rate at which the ATB bar fills, but also decreases how long beneficial Status Effects last. This effect will wear off automatically over time.',
+            ],
+            [
+                'name' => 'slow',
+                'type' => 'harmful',
+                'description' => 'The Slow status decreases the rate at which the ATB bar fills, but also increases how long beneficial Status Effects last. This effect will wear off automatically over time.',
+            ],
+            [
+                'name' => 'stop',
+                'type' => 'harmful',
+                'description' => 'The Stop status will render targets unable to execute any commands. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'regen',
+                'type' => 'beneficial',
+                'description' => 'The Regen status heals the target for a total of 80% of their maximum HP. This is done in 5% increments over the course of 16 ticks. This effect will wear off automatically over time.',
+            ],
+            [
+                'name' => 'protect',
+                'type' => 'beneficial',
+                'description' => 'The Protect status halves physical damage dealt to the target. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'shell',
+                'type' => 'beneficial',
+                'description' => 'The Shell status halves magical damage dealt to the target. This reduction also affects curing spells. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'reflect',
+                'type' => 'beneficial',
+                'description' => 'The Reflect status redirects most single-target magic toward a random target on the opposing team. Spells can only be reflected once. Not all magic can be reflected. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'aura',
+                'type' => 'beneficial',
+                'description' => 'The Aura status significantly increases the chances of a character being able to use a limit break. This status also enhances the power of limit breaks. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'curse',
+                'type' => 'harmful',
+                'description' => 'The Curse status restricts a character from using limit breaks. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'doom',
+                'type' => 'harmful',
+                'description' => "The Doom status places a countdown timer on the target. When this timer expires, the target will be KO'd. If the battle ends before the countdown has finished, the status will be removed.",
+            ],
+            [
+                'name' => 'invincible',
+                'type' => 'beneficial',
+                'description' => 'The Invincible status prevents targets from taking any form of damage. This status also prevents both beneficial, and harmful statuses from being applied to the target. Becoming Invincible removes any current negative status effects. Targets that are under the effect of Invincible can be healed by spells and items. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'petrifying',
+                'type' => 'harmful',
+                'description' => 'The Petrifying status places a countdown timer on the target. When this timer expired, the target will be afflicted with the Petrify status. If battle ends before the countdown has finished, the status will be removed.',
+            ],
+            [
+                'name' => 'float',
+                'type' => 'beneficial',
+                'description' => 'The Floating status makes targets immune to earth based damage. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'confuse',
+                'type' => 'harmful',
+                'description' => 'The Confuse status makes targets use attacks, magic, or items on any ally (including themselves) or enemy at random. This status will wear off at the end of battle, or if physical damage is taken. This effect wears off automatically over time.',
+            ],
+            [
+                'name' => 'double',
+                'type' => 'beneficial',
+                'description' => 'The Double status allows a target to cast magic twice in one turn. Casting two spells in one turn will consume two stocks of the spell that is cast. If the Expendx2-1 ability is in use, it will only consume one stocked spell. This effect will last until the end of battle.',
+            ],
+            [
+                'name' => 'triple',
+                'type' => 'beneficial',
+                'description' => 'The Triple status allows a target to cast magic three times in one turn. Casting three spells in one turn will consume three stocks of the spell that is cast. If the Expendx3-1 ability is in use, it will only consume one stocked spell. This effect will last until the end of battle.',
+            ],
+            [
+                'name' => 'defend',
+                'type' => 'beneficial',
+                'description' => 'The Defend status will prevent all physical damage and will halve magic damage received until another command is chosen. Physical attacks that can inflict status ailments will never have an effect on a target that under the Defend status.',
+            ],
+            [
+                'name' => 'vit 0',
+                'type' => 'harmful',
+                'description' => 'The Vit 0 status reduces both vitality and spirit to 0, making the target more vulnerable to both physical and magic attacks. This effect lasts until battle ends.',
+            ],
+            [
+                'name' => 'angel wing',
+                'type' => 'beneficial',
+                'description' => "The Angel Wing status is granted by Rinoa's Angel Wing limit break. This status will cause Rinoa to cast random spells on random targets, without consuming stocked spells. Spells deal 5 times the normal damage, and the effect lasts until the end of combat.",
+            ],
+            [
+                'name' => 'drain',
+                'type' => 'harmful',
+                'description' => "The Drain status is used exclusively for calculating the amount of hit points gained from using a Drain effect. If the target has Drain resistance, they will take normal damage, however the user will regain hit points proportional to the target's Drain resistance.",
+            ],
+        ];
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
+use App\Http\Controllers\V0\StatusEffectController;
 use App\Http\Controllers\V0\TestQuestionController;
 use Illuminate\Support\Facades\Route;
 
@@ -19,3 +20,6 @@ Route::get('/seed-tests/{test}')->uses([SeedTestController::class, 'show']);
 
 Route::get('/test-questions/')->uses([TestQuestionController::class, 'index']);
 Route::get('/test-questions/{id}')->uses([TestQuestionController::class, 'show']);
+
+Route::get('/status-effects/')->uses([StatusEffectController::class, 'index']);
+Route::get('/status-effects/{id}')->uses([StatusEffectController::class, 'show']);

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -27,6 +27,7 @@ class HealthCheckEndpointTest extends TestCase
                     'seed_ranks' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
                     'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
                     'test_questions' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
+                    'status_effects' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
                 ],
             ],
         ]);

--- a/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\StatusEffect;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatusEffectEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_status_effects()
+    {
+        $statusEffects = StatusEffect::factory()->count(10)->create();
+
+        $response = $this->get('/v0/status-effects');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_status_effect_using_the_id_key()
+    {
+        $statusEffect = StatusEffect::factory()->create();
+
+        $response = $this->get("/v0/status-effects/{$statusEffect->id}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $statusEffect->id,
+                'name' => $statusEffect->name,
+                'type' => $statusEffect->type,
+                'description' => $statusEffect->description,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_status_effect_using_the_name_key()
+    {
+        $statusEffect = StatusEffect::factory()->create();
+
+        $response = $this->get("/v0/status-effects/{$statusEffect->name}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $statusEffect->id,
+                'name' => $statusEffect->name,
+                'type' => $statusEffect->type,
+                'description' => $statusEffect->description,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/v0/status-effects/invalid');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_status_effects_via_the_name_column()
+    {
+        StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial']);
+
+        $response = $this->get('/v0/status-effects?search=slow');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_status_effects_via_the_type_column()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial']);
+
+        $response = $this->get('/v0/status-effects?search=harmful');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_status_effects_via_the_description_column()
+    {
+        StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful', 'description' => 'Group One']);
+        StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful', 'description' => 'Group One']);
+        $three = StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial', 'description' => 'Group Two']);
+
+        $response = $this->get('/v0/status-effects?search=two');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $three->id,
+                    'name' => $three->name,
+                    'type' => $three->type,
+                    'description' => $three->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_status_effects_via_the_name_column()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial']);
+
+        $response = $this->get('/v0/status-effects?name=sleep');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_status_effects_via_the_name_column_using_the_like_statement()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial']);
+
+        $response = $this->get('/v0/status-effects?name=like:sl');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_status_effects_via_the_type_column()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial']);
+
+        $response = $this->get('/v0/status-effects?type=harmful');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_status_effects_via_the_type_column_using_the_like_statement()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial']);
+
+        $response = $this->get('/v0/status-effects?type=like:harm');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_status_effects_via_the_description_column()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful', 'description' => 'Group One']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful', 'description' => 'Group One']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial', 'description' => 'Group Two']);
+
+        $response = $this->get('/v0/status-effects?description=Group%20One');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_status_effects_via_the_description_column_using_the_like_statement()
+    {
+        $one = StatusEffect::factory()->create(['name' => 'sleep', 'type' => 'harmful', 'description' => 'Group One']);
+        $two = StatusEffect::factory()->create(['name' => 'slow', 'type' => 'harmful', 'description' => 'Group One']);
+        StatusEffect::factory()->create(['name' => 'haste', 'type' => 'beneficial', 'description' => 'Group Two']);
+
+        $response = $this->get('/v0/status-effects?description=like:one');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'name' => $one->name,
+                    'type' => $one->type,
+                    'description' => $one->description,
+                ],
+                [
+                    'id' => $two->id,
+                    'name' => $two->name,
+                    'type' => $two->type,
+                    'description' => $two->description,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Models/StatusEffectTest.php
+++ b/tests/Unit/Models/StatusEffectTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\StatusEffect;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase as TestCase;
+
+class StatusEffectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('status_effects', $statusEffect->getTable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('name', $statusEffect->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $statusEffect = new StatusEffect();
+
+        $visibleFields = [
+            'id',
+            'name',
+            'type',
+            'description',
+        ];
+
+        $this->assertEquals($visibleFields, $statusEffect->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_cast_type_for_each_field()
+    {
+        $statusEffect = new StatusEffect();
+        $fields = $statusEffect->getCasts();
+
+        $expected = [
+            'id'          => 'string',
+            'name'        => 'string',
+            'type'        => 'string',
+            'description' => 'string',
+        ];
+
+        $this->assertEquals($expected, $fields);
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_searchable()
+    {
+        $statusEffect = new StatusEffect();
+
+        $expected = [
+            'name',
+            'type',
+            'description',
+        ];
+
+        $this->assertEquals($expected, $statusEffect->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_filterable()
+    {
+        $statusEffect = new StatusEffect();
+
+        $expected = [
+            'name',
+            'type',
+            'description',
+        ];
+
+        $this->assertEquals($expected, $statusEffect->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_route_key_name()
+    {
+        $statusEffect = new StatusEffect();
+
+        $this->assertEquals('name', $statusEffect->getRouteKeyName());
+    }
+}

--- a/tests/Unit/Transformers/V0/StatusEffectTransformerTest.php
+++ b/tests/Unit/Transformers/V0/StatusEffectTransformerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\V0\StatusEffectTransformer;
+use App\Models\StatusEffect;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Tests\TestCase;
+
+class StatusEffectTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_transform_a_single_record()
+    {
+        $statusEffect = StatusEffect::factory()->make([
+            'id' => 'some-random-uuid',
+            'name' => 'zombie',
+            'type' => 'harmful',
+            'description' => 'The Zombie status causes the target to act as if undead. This effect does not wear off on its own.',
+            'arbitrary' => 'data',
+        ]);
+
+        $transformer = new StatusEffectTransformer();
+
+        $transformedRecord = $transformer->transformRecord($statusEffect->toArray());
+
+        $this->assertEquals([
+            'id' => $statusEffect->id,
+            'name' => $statusEffect->name,
+            'type' => $statusEffect->type,
+            'description' => $statusEffect->description,
+        ], $transformedRecord);
+    }
+
+    /** @test */
+    public function it_will_transform_a_collection_of_records()
+    {
+        $statusEffects = StatusEffect::factory()->count(3)->make(new Sequence(
+            ['id' => 'one'],
+            ['id' => 'two'],
+            ['id' => 'three']
+        ));
+
+        $transformer = new StatusEffectTransformer();
+
+        $transformedRecords = $transformer->transformCollection($statusEffects->toArray());
+
+        $this->assertEquals([
+            [
+                'id' => $statusEffects[0]->id,
+                'name' => $statusEffects[0]->name,
+                'type' => $statusEffects[0]->type,
+                'description' => $statusEffects[0]->description,
+            ],
+            [
+                'id' => $statusEffects[1]->id,
+                'name' => $statusEffects[1]->name,
+                'type' => $statusEffects[1]->type,
+                'description' => $statusEffects[1]->description,
+            ],
+            [
+                'id' => $statusEffects[2]->id,
+                'name' => $statusEffects[2]->name,
+                'type' => $statusEffects[2]->type,
+                'description' => $statusEffects[2]->description,
+            ],
+        ], $transformedRecords);
+    }
+}


### PR DESCRIPTION
This introduces the Status Effect resource. The scaffolding follows suit with other resources within the system, albeit this time I've opted to pass on the overly verbose unit testing. Instead, test for this resource consist of feature tests for the new endpoints that have been added, as well as unit tests for the model and transformer to ensure that the structures in place are correct. Cover coverage still sits at 100% across the entire suite, so this should speed up development time for features moving forward.

The existing models have also been modified to remove the unnecessary Searchable import. For some reason PHPCS didn't catch this and left it in the class.