### PR TITLE
refactor: extract base class for record transformations (API-83)

### DIFF
--- a/app/Http/Transformers/RecordTransformer.php
+++ b/app/Http/Transformers/RecordTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Transformers;
+
+use App\Contracts\Transformers\RecordTransformer as RecordTransformerContract;
+
+class RecordTransformer implements RecordTransformerContract
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array $record The record to be transformed
+     *
+     * @return array
+     */
+    public function transformRecord(array $record): array
+    {
+        return [];
+    }
+
+    /**
+     * Transforms a collection of records to standardize the output.
+     *
+     * @param array $collection The collection of records to be transformed
+     *
+     * @return array
+     */
+    public function transformCollection(array $collection): array
+    {
+        $data = [];
+
+        foreach ($collection as $record) {
+            $data[] = $this->transformRecord($record);
+        }
+
+        return $data;
+    }
+}

--- a/app/Http/Transformers/V0/SeedRankTransformer.php
+++ b/app/Http/Transformers/V0/SeedRankTransformer.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Transformers\V0;
 
-use App\Contracts\Transformers\RecordTransformer;
+use App\Http\Transformers\RecordTransformer;
 
-class SeedRankTransformer implements RecordTransformer
+class SeedRankTransformer extends RecordTransformer
 {
     /**
      * Transforms an individual record to standardize the output.
@@ -20,23 +20,5 @@ class SeedRankTransformer implements RecordTransformer
             'rank' => $record['rank'],
             'salary' => $record['salary'],
         ];
-    }
-
-    /**
-     * Transforms a collection of records to standardize the output.
-     *
-     * @param array $collection The collection of records to be transformed
-     *
-     * @return array
-     */
-    public function transformCollection(array $collection): array
-    {
-        $data = [];
-
-        foreach ($collection as $record) {
-            $data[] = $this->transformRecord($record);
-        }
-
-        return $data;
     }
 }

--- a/app/Http/Transformers/V0/SeedTestTransformer.php
+++ b/app/Http/Transformers/V0/SeedTestTransformer.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Transformers\V0;
 
-use App\Contracts\Transformers\RecordTransformer;
+use App\Http\Transformers\RecordTransformer;
 
-class SeedTestTransformer implements RecordTransformer
+class SeedTestTransformer extends RecordTransformer
 {
     /**
      * Instance of the TestQuestionTransformer.
@@ -31,24 +31,6 @@ class SeedTestTransformer implements RecordTransformer
             $data['test_questions'] = $record['test_questions']
                 ? $this->getTestQuestionTransformer()->transformCollection($record['test_questions'])
                 : null;
-        }
-
-        return $data;
-    }
-
-    /**
-     * Transforms a collection of records to standardize the output.
-     *
-     * @param array $collection The collection of records to be transformed
-     *
-     * @return array
-     */
-    public function transformCollection(array $collection): array
-    {
-        $data = [];
-
-        foreach ($collection as $record) {
-            $data[] = $this->transformRecord($record);
         }
 
         return $data;

--- a/app/Http/Transformers/V0/StatusEffectTransformer.php
+++ b/app/Http/Transformers/V0/StatusEffectTransformer.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Transformers\V0;
 
-use App\Contracts\Transformers\RecordTransformer;
+use App\Http\Transformers\RecordTransformer;
 
-class StatusEffectTransformer implements RecordTransformer
+class StatusEffectTransformer extends RecordTransformer
 {
     /**
      * Transforms an individual record to standardize the output.
@@ -21,23 +21,5 @@ class StatusEffectTransformer implements RecordTransformer
             'type' => $record['type'],
             'description' => $record['description'],
         ];
-    }
-
-    /**
-     * Transforms a collection of records to standardize the output.
-     *
-     * @param array $collection The collection of records to be transformed
-     *
-     * @return array
-     */
-    public function transformCollection(array $collection): array
-    {
-        $data = [];
-
-        foreach ($collection as $record) {
-            $data[] = $this->transformRecord($record);
-        }
-
-        return $data;
     }
 }

--- a/app/Http/Transformers/V0/TestQuestionTransformer.php
+++ b/app/Http/Transformers/V0/TestQuestionTransformer.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Transformers\V0;
 
-use App\Contracts\Transformers\RecordTransformer;
+use App\Http\Transformers\RecordTransformer;
 
-class TestQuestionTransformer implements RecordTransformer
+class TestQuestionTransformer extends RecordTransformer
 {
     /**
      * Instance of the SeedTestTransformer.
@@ -35,24 +35,6 @@ class TestQuestionTransformer implements RecordTransformer
             $data['seed_test'] = $record['seed_test']
                 ? $this->getSeedTestTransformer()->transformRecord($record['seed_test'])
                 : null;
-        }
-
-        return $data;
-    }
-
-    /**
-     * Transforms a collection of records to standardize the output.
-     *
-     * @param array $collection The collection of records to be transformed
-     *
-     * @return array
-     */
-    public function transformCollection(array $collection): array
-    {
-        $data = [];
-
-        foreach ($collection as $record) {
-            $data[] = $this->transformRecord($record);
         }
 
         return $data;


### PR DESCRIPTION
The logic for transforming records was becoming a bit redundant. Each new transformer was duplicating logic for transforming a collection, while also extending the same base contract. This simply refactors the common logic into a base class that other classes may extend, thus reducing code duplication.