### PR TITLE
test: include missing unit test for base record transformer (API-86)

### DIFF
--- a/tests/Unit/Transformers/RecordTransformerTest.php
+++ b/tests/Unit/Transformers/RecordTransformerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\RecordTransformer;
+use Tests\TestCase;
+
+class RecordTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_return_an_empty_array_when_transforming_a_record_if_not_overridden()
+    {
+        $data = [
+            'id' => 'some-random-uuid',
+            'arbitrary' => 'data',
+        ];
+
+        $transformer = new RecordTransformer();
+
+        $transformedRecord = $transformer->transformRecord($data);
+
+        $this->assertEquals([], $transformedRecord);
+    }
+}


### PR DESCRIPTION
This simply adds a missing test for the base record transformer to ensure 100% code coverage for the testing suite.