### PR TITLE
refactor: extract base class for resource controllers (API-84)

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Contracts\Services\ModelService;
+use App\Contracts\Transformers\RecordTransformer;
+use App\Traits\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ResourceController extends Controller
+{
+    use ApiResponse;
+
+    /**
+     * Instance of the ModelService.
+     *
+     * @var ModelService
+     */
+    protected $service;
+
+    /**
+     * Instance of the RecordTransformer.
+     *
+     * @var RecordTransformer
+     */
+    protected $transformer;
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request The HTTP request from the client
+     *
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $records = $this->service->all($request);
+
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->transformer->transformCollection($records)
+        );
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param Request $request The HTTP request from the client
+     * @param string  $id      The ID of the requested record
+     *
+     * @return JsonResponse
+     */
+    public function show(Request $request, string $id): JsonResponse
+    {
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->transformer->transformRecord(
+                $this->service->findOrFail($id, $request)
+            )
+        );
+    }
+}

--- a/app/Http/Controllers/V0/SeedRankController.php
+++ b/app/Http/Controllers/V0/SeedRankController.php
@@ -3,30 +3,12 @@
 namespace App\Http\Controllers\V0;
 
 use App\Contracts\Services\SeedRankService;
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\ResourceController;
 use App\Http\Transformers\V0\SeedRankTransformer;
-use App\Traits\ApiResponse;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class SeedRankController extends Controller
+class SeedRankController extends ResourceController
 {
-    use ApiResponse;
-
-    /**
-     * Instance of the SeedRankService.
-     *
-     * @var SeedRankService
-     */
-    protected $seedRankService;
-
-    /**
-     * Instance of the SeedRankTransformer.
-     *
-     * @var SeedRankTransformer
-     */
-    protected $seedRankTransformer;
-
     /**
      * Create a new SeedRankController instance.
      *
@@ -35,42 +17,7 @@ class SeedRankController extends Controller
      */
     public function __construct(SeedRankService $seedRankService, SeedRankTransformer $seedRankTransformer)
     {
-        $this->seedRankService = $seedRankService;
-        $this->seedRankTransformer = $seedRankTransformer;
-    }
-
-    /**
-     * Display a listing of the resource.
-     *
-     * @param Request $request The HTTP request from the client
-     *
-     * @return JsonResponse
-     */
-    public function index(Request $request): JsonResponse
-    {
-        $records = $this->seedRankService->all($request);
-
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->seedRankTransformer->transformCollection($records)
-        );
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param Request $request    The HTTP request from the client
-     * @param string  $seedRankId The ID of the requested SeedRank
-     *
-     * @return JsonResponse
-     */
-    public function show(Request $request, string $seedRankId): JsonResponse
-    {
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->seedRankTransformer->transformRecord(
-                $this->seedRankService->findOrFail($seedRankId, $request)
-            )
-        );
+        $this->service = $seedRankService;
+        $this->transformer = $seedRankTransformer;
     }
 }

--- a/app/Http/Controllers/V0/SeedTestController.php
+++ b/app/Http/Controllers/V0/SeedTestController.php
@@ -3,30 +3,12 @@
 namespace App\Http\Controllers\V0;
 
 use App\Contracts\Services\SeedTestService;
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\ResourceController;
 use App\Http\Transformers\V0\SeedTestTransformer;
-use App\Traits\ApiResponse;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class SeedTestController extends Controller
+class SeedTestController extends ResourceController
 {
-    use ApiResponse;
-
-    /**
-     * Instance of the SeedTestService.
-     *
-     * @var SeedTestService
-     */
-    protected $seedTestService;
-
-    /**
-     * Instance of the SeedTestTransformer.
-     *
-     * @var SeedTestTransformer
-     */
-    protected $seedTestTransformer;
-
     /**
      * Create a new SeedTestController instance.
      *
@@ -35,42 +17,7 @@ class SeedTestController extends Controller
      */
     public function __construct(SeedTestService $seedTestService, SeedTestTransformer $seedTestTransformer)
     {
-        $this->seedTestService = $seedTestService;
-        $this->seedTestTransformer = $seedTestTransformer;
-    }
-
-    /**
-     * Display a listing of the resource.
-     *
-     * @param Request $request The HTTP request from the client
-     *
-     * @return JsonResponse
-     */
-    public function index(Request $request): JsonResponse
-    {
-        $records = $this->seedTestService->all($request);
-
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->seedTestTransformer->transformCollection($records)
-        );
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param Request $request    The HTTP request from the client
-     * @param string  $seedTestId The ID of the requested SeedTest
-     *
-     * @return JsonResponse
-     */
-    public function show(Request $request, string $seedTestId): JsonResponse
-    {
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->seedTestTransformer->transformRecord(
-                $this->seedTestService->findOrFail($seedTestId, $request)
-            )
-        );
+        $this->service = $seedTestService;
+        $this->transformer = $seedTestTransformer;
     }
 }

--- a/app/Http/Controllers/V0/StatusEffectController.php
+++ b/app/Http/Controllers/V0/StatusEffectController.php
@@ -3,30 +3,12 @@
 namespace App\Http\Controllers\V0;
 
 use App\Contracts\Services\StatusEffectService;
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\ResourceController;
 use App\Http\Transformers\V0\StatusEffectTransformer;
-use App\Traits\ApiResponse;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class StatusEffectController extends Controller
+class StatusEffectController extends ResourceController
 {
-    use ApiResponse;
-
-    /**
-     * Instance of the StatusEffectService.
-     *
-     * @var StatusEffectService
-     */
-    protected $statusEffectService;
-
-    /**
-     * Instance of the StatusEffectTransformer.
-     *
-     * @var StatusEffectTransformer
-     */
-    protected $statusEffectTransformer;
-
     /**
      * Create a new StatusEffectController instance.
      *
@@ -35,42 +17,7 @@ class StatusEffectController extends Controller
      */
     public function __construct(StatusEffectService $statusEffectService, StatusEffectTransformer $statusEffectTransformer)
     {
-        $this->statusEffectService = $statusEffectService;
-        $this->statusEffectTransformer = $statusEffectTransformer;
-    }
-
-    /**
-     * Display a listing of the resource.
-     *
-     * @param Request $request The HTTP request from the client
-     *
-     * @return JsonResponse
-     */
-    public function index(Request $request): JsonResponse
-    {
-        $records = $this->statusEffectService->all($request);
-
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->statusEffectTransformer->transformCollection($records)
-        );
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param Request $request        The HTTP request from the client
-     * @param string  $statusEffectId The ID of the requested StatusEffect
-     *
-     * @return JsonResponse
-     */
-    public function show(Request $request, string $statusEffectId): JsonResponse
-    {
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->statusEffectTransformer->transformRecord(
-                $this->statusEffectService->findOrFail($statusEffectId, $request)
-            )
-        );
+        $this->service = $statusEffectService;
+        $this->transformer = $statusEffectTransformer;
     }
 }

--- a/app/Http/Controllers/V0/TestQuestionController.php
+++ b/app/Http/Controllers/V0/TestQuestionController.php
@@ -3,30 +3,12 @@
 namespace App\Http\Controllers\V0;
 
 use App\Contracts\Services\TestQuestionService;
-use App\Http\Controllers\Controller;
+use App\Http\Controllers\ResourceController;
 use App\Http\Transformers\V0\TestQuestionTransformer;
-use App\Traits\ApiResponse;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class TestQuestionController extends Controller
+class TestQuestionController extends ResourceController
 {
-    use ApiResponse;
-
-    /**
-     * Instance of the TestQuestionService.
-     *
-     * @var TestQuestionService
-     */
-    protected $testQuestionService;
-
-    /**
-     * Instance of the TestQuestionTransformer.
-     *
-     * @var TestQuestionTransformer
-     */
-    protected $testQuestionTransformer;
-
     /**
      * Create a new TestQuestionController instance.
      *
@@ -35,42 +17,7 @@ class TestQuestionController extends Controller
      */
     public function __construct(TestQuestionService $testQuestionService, TestQuestionTransformer $testQuestionTransformer)
     {
-        $this->testQuestionService = $testQuestionService;
-        $this->testQuestionTransformer = $testQuestionTransformer;
-    }
-
-    /**
-     * Display a listing of the resource.
-     *
-     * @param Request $request The HTTP request from the client
-     *
-     * @return JsonResponse
-     */
-    public function index(Request $request): JsonResponse
-    {
-        $records = $this->testQuestionService->all($request);
-
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->testQuestionTransformer->transformCollection($records)
-        );
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param Request $request        The HTTP request from the client
-     * @param string  $testQuestionId The ID of the requested TestQuestion
-     *
-     * @return JsonResponse
-     */
-    public function show(Request $request, string $testQuestionId): JsonResponse
-    {
-        return $this->respondWithSuccess(
-            'Successfully retrieved data.',
-            $this->testQuestionTransformer->transformRecord(
-                $this->testQuestionService->findOrFail($testQuestionId, $request)
-            )
-        );
+        $this->service = $testQuestionService;
+        $this->transformer = $testQuestionTransformer;
     }
 }


### PR DESCRIPTION
Resource controllers are beginning to duplicate the same logic across classes. This logic is laregly the same across each class, albeit with slightly different variable names for clarity and slightly different resources being injected. Instead of duplicating this logic across all classes, a base resource controller has been created which allows for customization via extension for each specific resource.