### PR TITLE
feat: add stat resource (API-11)

### DIFF
--- a/app/Http/Transformers/V0/StatTransformer.php
+++ b/app/Http/Transformers/V0/StatTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Transformers\V0;
+
+use App\Http\Transformers\RecordTransformer;
+
+class StatTransformer extends RecordTransformer
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array $record The record to be transformed
+     *
+     * @return array
+     */
+    public function transformRecord(array $record): array
+    {
+        return [
+            'id' => $record['id'],
+            'sort_id' => $record['sort_id'],
+            'name' => $record['name'],
+            'abbreviation' => $record['abbreviation'],
+        ];
+    }
+}

--- a/app/Models/Stat.php
+++ b/app/Models/Stat.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Stat extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'stats';
+
+    /**
+     * The default field used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByField = 'sort_id';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'sort_id',
+        'name',
+        'abbreviation',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id'           => 'string',
+        'sort_id'      => 'integer',
+        'name'         => 'string',
+        'abbreviation' => 'string',
+    ];
+
+    /**
+     * The fields that should be searchable.
+     *
+     * @var array
+     */
+    protected $searchableFields = [];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
+    protected $filterableFields = [];
+}

--- a/database/factories/StatFactory.php
+++ b/database/factories/StatFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Stat;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class StatFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Stat::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'sort_id' => $this->faker->unique()->numberBetween(1, 9),
+            'name' => $this->faker->word,
+            'abbreviation' => $this->faker->word,
+        ];
+    }
+}

--- a/database/migrations/2021_09_23_031132_create_stats_table.php
+++ b/database/migrations/2021_09_23_031132_create_stats_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStatsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('stats', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->integer('sort_id');
+            $table->string('name');
+            $table->string('abbreviation');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('stats');
+    }
+}

--- a/database/seeders/StatsTableSeeder.php
+++ b/database/seeders/StatsTableSeeder.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Stat;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class StatsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $stats = $this->getStats();
+
+        foreach ($stats as $key => $value) {
+            $stats[$key]['id'] = Uuid::generate(4);
+            $stats[$key]['created_at'] = Carbon::now();
+            $stats[$key]['updated_at'] = Carbon::now();
+        }
+
+        $stat = new Stat();
+
+        $stat->insert($stats);
+    }
+
+    /**
+     * The Stats to be inserted into the database.
+     *
+     * @return array
+     */
+    public function getStats(): array
+    {
+        return [
+            [
+                'sort_id' => 1,
+                'name' => 'hit points',
+                'abbreviation' => 'hp',
+            ],
+            [
+                'sort_id' => 2,
+                'name' => 'strength',
+                'abbreviation' => 'str',
+            ],
+            [
+                'sort_id' => 3,
+                'name' => 'vitality',
+                'abbreviation' => 'vit',
+            ],
+            [
+                'sort_id' => 4,
+                'name' => 'magic',
+                'abbreviation' => 'mag',
+            ],
+            [
+                'sort_id' => 5,
+                'name' => 'spirit',
+                'abbreviation' => 'spr',
+            ],
+            [
+                'sort_id' => 6,
+                'name' => 'speed',
+                'abbreviation' => 'spd',
+            ],
+            [
+                'sort_id' => 7,
+                'name' => 'luck',
+                'abbreviation' => 'luck',
+            ],
+            [
+                'sort_id' => 8,
+                'name' => 'evade',
+                'abbreviation' => 'eva',
+            ],
+            [
+                'sort_id' => 9,
+                'name' => 'hit',
+                'abbreviation' => 'hit',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Models/StatTest.php
+++ b/tests/Unit/Models/StatTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Stat;
+use Tests\TestCase as TestCase;
+
+class StatTest extends TestCase
+{
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $stat = new Stat();
+
+        $this->assertEquals('stats', $stat->getTable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    {
+        $stat = new Stat();
+
+        $this->assertEquals('sort_id', $stat->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $stat = new Stat();
+
+        $visibleFields = [
+            'id',
+            'sort_id',
+            'name',
+            'abbreviation',
+        ];
+
+        $this->assertEquals($visibleFields, $stat->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_cast_type_for_each_field()
+    {
+        $stat = new Stat();
+        $fields = $stat->getCasts();
+
+        $expected = [
+            'id'           => 'string',
+            'sort_id'      => 'integer',
+            'name'         => 'string',
+            'abbreviation' => 'string',
+        ];
+
+        $this->assertEquals($expected, $fields);
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_searchable()
+    {
+        $stat = new Stat();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $stat->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_filterable()
+    {
+        $stat = new Stat();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $stat->getFilterableFields());
+    }
+}

--- a/tests/Unit/Transformers/V0/StatTransformerTest.php
+++ b/tests/Unit/Transformers/V0/StatTransformerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\V0\StatTransformer;
+use App\Models\Stat;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Tests\TestCase;
+
+class StatTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_transform_a_single_record()
+    {
+        $stat = Stat::factory()->make([
+            'id' => 'some-random-uuid',
+            'sort_id' => '1',
+            'name' => 'hit points',
+            'abbreviation' => 'hp',
+            'arbitrary' => 'data',
+        ]);
+
+        $transformer = new StatTransformer();
+
+        $transformedRecord = $transformer->transformRecord($stat->toArray());
+
+        $this->assertEquals([
+            'id' => $stat->id,
+            'sort_id' => $stat->sort_id,
+            'name' => $stat->name,
+            'abbreviation' => $stat->abbreviation,
+        ], $transformedRecord);
+    }
+
+    /** @test */
+    public function it_will_transform_a_collection_of_records()
+    {
+        $stats = Stat::factory()->count(3)->make(new Sequence(
+            ['id' => 'one'],
+            ['id' => 'two'],
+            ['id' => 'three']
+        ));
+
+        $transformer = new StatTransformer();
+
+        $transformedRecords = $transformer->transformCollection($stats->toArray());
+
+        $this->assertEquals([
+            [
+                'id' => $stats[0]->id,
+                'sort_id' => $stats[0]->sort_id,
+                'name' => $stats[0]->name,
+                'abbreviation' => $stats[0]->abbreviation,
+            ],
+            [
+                'id' => $stats[1]->id,
+                'sort_id' => $stats[1]->sort_id,
+                'name' => $stats[1]->name,
+                'abbreviation' => $stats[1]->abbreviation,
+            ],
+            [
+                'id' => $stats[2]->id,
+                'sort_id' => $stats[2]->sort_id,
+                'name' => $stats[2]->name,
+                'abbreviation' => $stats[2]->abbreviation,
+            ],
+        ], $transformedRecords);
+    }
+}


### PR DESCRIPTION
This introduces the Stat resource. The included scaffolding is a bit more barebones than what is present with typical resources. The Stat resource only includes a model and a transformer. It does not include endpoints or controllers as they will not be used. Instead, this resource will only be used through relationships as a way to standardize commonly used attributes.