### PR TITLE
feat: add element resource (API-5)

### DIFF
--- a/app/Contracts/Services/ElementService.php
+++ b/app/Contracts/Services/ElementService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Contracts\Services;
+
+interface ElementService extends ModelService
+{
+}

--- a/app/Http/Controllers/V0/ElementController.php
+++ b/app/Http/Controllers/V0/ElementController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\ElementService;
+use App\Http\Controllers\ResourceController;
+use App\Http\Transformers\V0\ElementTransformer;
+use Illuminate\Http\Request;
+
+class ElementController extends ResourceController
+{
+    /**
+     * Create a new ElementController instance.
+     *
+     * @param ElementService     $elementService     The Service that will process the request
+     * @param ElementTransformer $elementTransformer The Transformer that will standardize the response
+     */
+    public function __construct(ElementService $elementService, ElementTransformer $elementTransformer)
+    {
+        $this->service = $elementService;
+        $this->transformer = $elementTransformer;
+    }
+}

--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -27,6 +27,7 @@ class HealthCheckController extends Controller
                 'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
                 'test_questions' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
                 'status_effects' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
+                'elements' => "{$baseUrl}/v{$currentApiVersion}/elements",
             ],
         ]);
     }

--- a/app/Http/Transformers/V0/ElementTransformer.php
+++ b/app/Http/Transformers/V0/ElementTransformer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Transformers\V0;
+
+use App\Http\Transformers\RecordTransformer;
+
+class ElementTransformer extends RecordTransformer
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array $record The record to be transformed
+     *
+     * @return array
+     */
+    public function transformRecord(array $record): array
+    {
+        return [
+            'id' => $record['id'],
+            'sort_id' => $record['sort_id'],
+            'name' => $record['name'],
+        ];
+    }
+}

--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Element extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'elements';
+
+    /**
+     * The default field used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByField = 'sort_id';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'sort_id',
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id'      => 'string',
+        'sort_id' => 'integer',
+        'name'    => 'string',
+    ];
+
+    /**
+     * The fields that should be searchable.
+     *
+     * @var array
+     */
+    protected $searchableFields = [
+        'name',
+    ];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @return array
+     */
+    protected $filterableFields = [
+        'name',
+    ];
+
+    /*
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'name';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,6 +34,11 @@ class AppServiceProvider extends ServiceProvider
             \App\Services\StatusEffectService::class
         );
 
+        $this->app->bind(
+            \App\Contracts\Services\ElementService::class,
+            \App\Services\ElementService::class
+        );
+
         $this->app->singleton(CaptureInboundRequest::class);
     }
 

--- a/app/Services/ElementService.php
+++ b/app/Services/ElementService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Services\ElementService as ElementServiceContract;
+use App\Models\Element;
+
+class ElementService extends ModelService implements ElementServiceContract
+{
+    /**
+     * Create a new ElementService instance.
+     *
+     * @param Element $model The instance of the model to use for the service
+     */
+    public function __construct(Element $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/database/factories/ElementFactory.php
+++ b/database/factories/ElementFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Element;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ElementFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Element::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'sort_id' => $this->faker->unique()->numberBetween(1, 8),
+            'name' => $this->faker->word(),
+        ];
+    }
+}

--- a/database/migrations/2021_10_05_020551_create_elements_table.php
+++ b/database/migrations/2021_10_05_020551_create_elements_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateElementsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('elements', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->integer('sort_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('elements');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,5 +17,7 @@ class DatabaseSeeder extends Seeder
         $this->call(SeedTestsTableSeeder::class);
         $this->call(TestQuestionsTableSeeder::class);
         $this->call(StatusEffectsTableSeeder::class);
+        $this->call(StatsTableSeeder::class);
+        $this->call(ElementsTableSeeder::class);
     }
 }

--- a/database/seeders/ElementsTableSeeder.php
+++ b/database/seeders/ElementsTableSeeder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Element;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Webpatser\Uuid\Uuid;
+
+class ElementsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $elements = [
+            ['sort_id' => 1, 'name' => 'fire'],
+            ['sort_id' => 2, 'name' => 'ice'],
+            ['sort_id' => 3, 'name' => 'thunder'],
+            ['sort_id' => 4, 'name' => 'earth'],
+            ['sort_id' => 5, 'name' => 'poison'],
+            ['sort_id' => 6, 'name' => 'wind'],
+            ['sort_id' => 7, 'name' => 'water'],
+            ['sort_id' => 8, 'name' => 'holy'],
+        ];
+
+        foreach ($elements as $key => $value) {
+            $elements[$key]['id'] = Uuid::generate(4);
+            $elements[$key]['created_at'] = Carbon::now();
+            $elements[$key]['updated_at'] = Carbon::now();
+        }
+
+        $element = new Element();
+
+        $element->insert($elements);
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\V0\ElementController;
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
@@ -23,3 +24,6 @@ Route::get('/test-questions/{id}')->uses([TestQuestionController::class, 'show']
 
 Route::get('/status-effects/')->uses([StatusEffectController::class, 'index']);
 Route::get('/status-effects/{id}')->uses([StatusEffectController::class, 'show']);
+
+Route::get('/elements/')->uses([ElementController::class, 'index']);
+Route::get('/elements/{id}')->uses([ElementController::class, 'show']);

--- a/tests/Feature/Endpoints/V0/ElementEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/ElementEndpointTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\Element;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ElementEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_elements()
+    {
+        $elements = Element::factory()->count(8)->create();
+
+        $response = $this->get('/v0/elements');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(8, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_element_using_the_id_key()
+    {
+        $element = Element::factory()->create();
+
+        $response = $this->get("/v0/elements/{$element->id}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $element->id,
+                'sort_id' => $element->sort_id,
+                'name' => $element->name,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_element_using_the_name_key()
+    {
+        $element = Element::factory()->create();
+
+        $response = $this->get("/v0/elements/{$element->name}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $element->id,
+                'sort_id' => $element->sort_id,
+                'name' => $element->name,
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    {
+        $response = $this->get('/v0/elements/invalid');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_search_for_elements_via_the_name_column()
+    {
+        Element::factory()->create(['sort_id' => 1, 'name' => 'fire']);
+        $two = Element::factory()->create(['sort_id' => 3, 'name' => 'thunder']);
+        $three = Element::factory()->create(['sort_id' => 7, 'name' => 'water']);
+
+        $response = $this->get('/v0/elements?search=er');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $two->id,
+                    'sort_id' => $two->sort_id,
+                    'name' => $two->name,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'name' => $three->name,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_elements_via_the_name_column()
+    {
+        $one = Element::factory()->create(['sort_id' => 1, 'name' => 'fire']);
+        Element::factory()->create(['sort_id' => 3, 'name' => 'thunder']);
+        Element::factory()->create(['sort_id' => 7, 'name' => 'water']);
+
+        $response = $this->get('/v0/elements?name=fire');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $one->id,
+                    'sort_id' => $one->sort_id,
+                    'name' => $one->name,
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_filter_elements_via_the_name_column_using_the_like_statement()
+    {
+        Element::factory()->create(['sort_id' => 1, 'name' => 'fire']);
+        $two = Element::factory()->create(['sort_id' => 3, 'name' => 'thunder']);
+        $three = Element::factory()->create(['sort_id' => 7, 'name' => 'water']);
+
+        $response = $this->get('/v0/elements?name=like:er');
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                [
+                    'id' => $two->id,
+                    'sort_id' => $two->sort_id,
+                    'name' => $two->name,
+                ],
+                [
+                    'id' => $three->id,
+                    'sort_id' => $three->sort_id,
+                    'name' => $three->name,
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -28,6 +28,7 @@ class HealthCheckEndpointTest extends TestCase
                     'seed_tests' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
                     'test_questions' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
                     'status_effects' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
+                    'elements' => "{$baseUrl}/v{$currentApiVersion}/elements",
                 ],
             ],
         ]);

--- a/tests/Unit/Models/ElementTest.php
+++ b/tests/Unit/Models/ElementTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Element;
+use Tests\TestCase as TestCase;
+
+class ElementTest extends TestCase
+{
+    /** @test */
+    public function it_uses_the_proper_database_table()
+    {
+        $element = new Element();
+
+        $this->assertEquals('elements', $element->getTable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    {
+        $element = new Element();
+
+        $this->assertEquals('sort_id', $element->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    {
+        $element = new Element();
+
+        $visibleFields = [
+            'id',
+            'sort_id',
+            'name',
+        ];
+
+        $this->assertEquals($visibleFields, $element->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_cast_type_for_each_field()
+    {
+        $element = new Element();
+        $fields = $element->getCasts();
+
+        $expected = [
+            'id'      => 'string',
+            'sort_id' => 'integer',
+            'name'    => 'string',
+        ];
+
+        $this->assertEquals($expected, $fields);
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_searchable()
+    {
+        $element = new Element();
+
+        $expected = [
+            'name',
+        ];
+
+        $this->assertEquals($expected, $element->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_filterable()
+    {
+        $element = new Element();
+
+        $expected = [
+            'name',
+        ];
+
+        $this->assertEquals($expected, $element->getFilterableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_route_key_name()
+    {
+        $element = new Element();
+
+        $this->assertEquals('name', $element->getRouteKeyName());
+    }
+}

--- a/tests/Unit/Transformers/V0/ElementTransformerTest.php
+++ b/tests/Unit/Transformers/V0/ElementTransformerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\V0\ElementTransformer;
+use App\Models\Element;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Tests\TestCase;
+
+class ElementTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_transform_a_single_record()
+    {
+        $element = Element::factory()->make([
+            'id' => 'some-random-uuid',
+            'sort_id' => 1,
+            'name' => 'fire',
+            'arbitrary' => 'data',
+        ]);
+
+        $transformer = new ElementTransformer();
+
+        $transformedRecord = $transformer->transformRecord($element->toArray());
+
+        $this->assertEquals([
+            'id' => $element->id,
+            'sort_id' => $element->sort_id,
+            'name' => $element->name,
+        ], $transformedRecord);
+    }
+
+    /** @test */
+    public function it_will_transform_a_collection_of_records()
+    {
+        $elements = Element::factory()->count(3)->make(new Sequence(
+            ['id' => 'one', 'sort_id' => 1],
+            ['id' => 'two', 'sort_id' => 2],
+            ['id' => 'three', 'sort_id' => 3]
+        ));
+
+        $transformer = new ElementTransformer();
+
+        $transformedRecords = $transformer->transformCollection($elements->toArray());
+
+        $this->assertEquals([
+            [
+                'id' => $elements[0]->id,
+                'sort_id' => $elements[0]->sort_id,
+                'name' => $elements[0]->name,
+            ],
+            [
+                'id' => $elements[1]->id,
+                'sort_id' => $elements[1]->sort_id,
+                'name' => $elements[1]->name,
+            ],
+            [
+                'id' => $elements[2]->id,
+                'sort_id' => $elements[2]->sort_id,
+                'name' => $elements[2]->name,
+            ],
+        ], $transformedRecords);
+    }
+}


### PR DESCRIPTION
Introduces the Element resource to the system. Not much to outline for this as it's all really the same scaffolding as with previous additions. This resource includes two endpoints for the `index` and `show` actions. The status endpoint has also been updated to include the new resource information. Testing isn't as robust as when this project was initially started. Only the necessary test cases have been included to keep development times down and to keep from duplicating test cases when they are not needed. Code coverage is still at 100%, so dropping the duplicate scenarios didn't impact anything on that front.