### PR TITLE
docs: update changelog to include missing ticket number (API-87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* add element resource ([#39](https://github.com/DefrostedTuna/viiidb-api/issues/39)) ([c057609](https://github.com/DefrostedTuna/viiidb-api/commit/c05760971a7053fc9149faa593d5d3e7c5797361))
-* add sort_id to the status effect resource (API-85) ([#40](https://github.com/DefrostedTuna/viiidb-api/issues/40)) ([ab61295](https://github.com/DefrostedTuna/viiidb-api/commit/ab612958546c8590379e5491a152b5e6fc411a5b))
 * add stat resource (API-11) ([#38](https://github.com/DefrostedTuna/viiidb-api/issues/38)) ([6f9bd87](https://github.com/DefrostedTuna/viiidb-api/commit/6f9bd87e6340c4c03ac1f0a0b64a894f644ca0c4))
+* add element resource (API-5) ([#39](https://github.com/DefrostedTuna/viiidb-api/issues/39)) ([c057609](https://github.com/DefrostedTuna/viiidb-api/commit/c05760971a7053fc9149faa593d5d3e7c5797361))
+* add sort_id to the status effect resource (API-85) ([#40](https://github.com/DefrostedTuna/viiidb-api/issues/40)) ([ab61295](https://github.com/DefrostedTuna/viiidb-api/commit/ab612958546c8590379e5491a152b5e6fc411a5b))
 
 ## [0.2.6](https://github.com/DefrostedTuna/viiidb-api/compare/0.2.5...0.2.6) (2021-09-22)
 


### PR DESCRIPTION
When merging the changes for the Elements resource, the tag was unintentionally left out of the commit message. This will simply include the missing ticket number on the changelog that was generated from said commit message to keep a more accurate log. The order of the features for the associated release was also modified so that it reflects the order the changes were made.