### PR TITLE
chore: develop using devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "VIIIDB API",
+	"dockerComposeFile": [
+		"../docker-compose.yaml"
+	],
+	"service": "viiidb-api",
+	"workspaceFolder": "/app",
+	"settings": {
+    "phpunit.command": ""
+  },
+	"extensions": [
+    "junstyle.php-cs-fixer",
+    "xdebug.php-debug",
+    "bmewburn.vscode-intelephense-client",
+    "emallin.phpunit"
+	],
+	"remoteUser": "www"
+}

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,12 @@
+FROM defrostedtuna/php-nginx:8.0-dev
+
+# Git and OpenSSH are needed for the Remote Containers setup.
+RUN apk add --no-cache \
+  git \
+  openssh
+
+# Increase the PHP memory limit for development.
+RUN echo $'\nmemory_limit = 1G' >> /etc/php/php.ini 
+
+# Let's make the terminal look nicer.
+RUN echo 'export PS1="┌─ 🐳 \[\e[0;1;30;43m\] \u \[\e[0m\]\[\e[0;1;30;46m\] \h \[\e[0m\]\[\e[0;1;30;47m\] \w \[\e[0m\] \n└─ $ "' >> /etc/profile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,11 @@ version: '3.5'
 
 services:
   viiidb-api:
-    image: defrostedtuna/php-nginx:8.0-dev
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
     container_name: viiidb-api
+    hostname: viiidb-api
     volumes:
       - ./:/app
     environment:


### PR DESCRIPTION
Includes the scaffolding needed to start using devcontainers within VSCode.

To get started with VSCode and devcontainers, ensure that the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) VSCode extension is installed. From there, simply open the project within a the included container via the extension. The global resources will still be needed. However, everything done within VSCode will now be in the context of the container and there is no more need to prefix terminal commands with `docker-compose exec`.