### PR TITLE
build: include phpstan support

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -10,29 +10,25 @@ class Kernel extends ConsoleKernel
     /**
      * The Artisan commands provided by your application.
      *
-     * @var array
+     * @var string[]
      */
     protected $commands = [
-        //
     ];
 
     /**
      * Define the application's command schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @return void
+     * @param Schedule $schedule
      */
-    protected function schedule(Schedule $schedule)
+    protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
     }
 
     /**
      * Register the commands for the application.
-     *
-     * @return void
      */
-    protected function commands()
+    protected function commands(): void
     {
         $this->load(__DIR__.'/Commands');
 

--- a/app/Contracts/Services/ModelService.php
+++ b/app/Contracts/Services/ModelService.php
@@ -12,7 +12,7 @@ interface ModelService
      *
      * @param Request $request The HTTP request from the client
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function all(Request $request): array;
 
@@ -24,7 +24,7 @@ interface ModelService
      *
      * @throws NotFoundHttpException
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function findOrFail(string $id, Request $request): array;
 }

--- a/app/Contracts/Transformers/RecordTransformer.php
+++ b/app/Contracts/Transformers/RecordTransformer.php
@@ -7,18 +7,18 @@ interface RecordTransformer
     /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array;
 
     /**
      * Transforms a collection of records to standardize the output.
      *
-     * @param array $collection The collection of records to be transformed
+     * @param array<int, array<string, mixed>> $collection The collection of records to be transformed
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function transformCollection(array $collection): array;
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,7 +5,9 @@ namespace App\Exceptions;
 use App\Traits\ApiResponse;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -15,7 +17,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontReport = [
     ];
@@ -23,7 +25,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontFlash = [
         'current_password',
@@ -33,10 +35,8 @@ class Handler extends ExceptionHandler
 
     /**
      * Register the exception handling callbacks for the application.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->reportable(function (Throwable $e) {
         });
@@ -45,11 +45,9 @@ class Handler extends ExceptionHandler
     /**
      * Report or log an exception.
      *
-     * @param Throwable $e
-     *
-     * @return void
+     * @param Throwable $e The exception that was thrown
      */
-    public function report(Throwable $e)
+    public function report(Throwable $e): void
     {
         if (app()->bound('sentry') && $this->shouldReport($e)) {
             app('sentry')->captureException($e);
@@ -61,14 +59,14 @@ class Handler extends ExceptionHandler
     /**
      * Render an exception into an HTTP response.
      *
-     * @param \Illuminate\Http\Request $request The HTTP request from the client
-     * @param Throwable                $e       The exception that was thrown
+     * @param Request   $request The HTTP request from the client
+     * @param Throwable $e       The exception that was thrown
      *
      * @return Response
      */
     public function render($request, Throwable $e): Response
     {
-        if ($request->route() && in_array('api', $request->route()->middleware())) {
+        if ($this->requestShouldHaveJsonHeaders($request)) {
             $request->headers->set('accept', 'application/json');
         }
 
@@ -88,14 +86,31 @@ class Handler extends ExceptionHandler
      */
     protected function handleJsonException(Throwable $e): JsonResponse
     {
+        $statusCode = 500;
         $message = config('app.debug')
             ? $e->getMessage()
             : ($this->isHttpException($e) ? $e->getMessage() : 'Server Error');
 
+        if ($e instanceof HttpExceptionInterface) {
+            $statusCode = $e->getStatusCode();
+        }
+
         return $this->respondWithError(
             $message,
             $this->convertExceptionToArray($e),
-            $this->isHttpException($e) ? $e->getStatusCode() : 500
+            $statusCode
         );
+    }
+
+    /**
+     * Determine whether or not the request should have JSON headers.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    protected function requestShouldHaveJsonHeaders(Request $request): bool
+    {
+        return $request->route() && in_array('api', (array) $request->route()->middleware());
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -105,7 +105,7 @@ class Handler extends ExceptionHandler
     /**
      * Determine whether or not the request should have JSON headers.
      *
-     * @param Request $request
+     * @param Request $request The HTTP request from the client
      *
      * @return bool
      */

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -11,7 +11,7 @@ class Kernel extends HttpKernel
      *
      * These middleware are run during every request to your application.
      *
-     * @var array
+     * @var string[]
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
     /**
      * The application's route middleware groups.
      *
-     * @var array
+     * @var array<string, string[]>
      */
     protected $middlewareGroups = [
         'api' => [
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
      *
      * These middleware may be assigned to groups or used individually.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $routeMiddleware = [
         'auth' => \App\Http\Middleware\Authenticate::class,

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -3,19 +3,23 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Http\Request;
 
 class Authenticate extends Middleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param Request $request
+     *
      * @return string|null
      */
-    protected function redirectTo($request)
+    protected function redirectTo($request): ?string
     {
         if (! $request->expectsJson()) {
             return route('login');
         }
+
+        return null;
     }
 }

--- a/app/Http/Middleware/CaptureInboundRequest.php
+++ b/app/Http/Middleware/CaptureInboundRequest.php
@@ -14,7 +14,7 @@ class CaptureInboundRequest
     /**
      * The time at which the request was first processed.
      *
-     * @var int
+     * @var float
      */
     protected $startTime = 0;
 
@@ -26,7 +26,7 @@ class CaptureInboundRequest
      *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): mixed
     {
         $this->startTime = microtime(true);
 
@@ -38,13 +38,11 @@ class CaptureInboundRequest
      *
      * @param Request      $request  The HTTP request from the client
      * @param JsonResponse $response The response sent back to the client
-     *
-     * @return void
      */
-    public function terminate(Request $request, JsonResponse $response)
+    public function terminate(Request $request, JsonResponse $response): void
     {
         $endTime = microtime(true);
-        $timeInMilliseconds = number_format($endTime - $this->startTime, 3) * 1000;
+        $timeInMilliseconds = number_format(($endTime - $this->startTime) * 1000, 3);
 
         DB::table('inbound_requests')->insert([
             'id' => Uuid::generate(4),

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -9,9 +9,8 @@ class EncryptCookies extends Middleware
     /**
      * The names of the cookies that should not be encrypted.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
-        //
     ];
 }

--- a/app/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/app/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -9,9 +9,8 @@ class PreventRequestsDuringMaintenance extends Middleware
     /**
      * The URIs that should be reachable while maintenance mode is enabled.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
-        //
     ];
 }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -12,12 +12,13 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  string|null  ...$guards
+     * @param Request     $request
+     * @param Closure     $next
+     * @param string|null ...$guards
+     *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next, ...$guards)
+    public function handle(Request $request, Closure $next, ...$guards): mixed
     {
         $guards = empty($guards) ? [null] : $guards;
 

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -9,7 +9,7 @@ class TrimStrings extends Middleware
     /**
      * The names of the attributes that should not be trimmed.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
         'current_password',

--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -9,9 +9,9 @@ class TrustHosts extends Middleware
     /**
      * Get the host patterns that should be trusted.
      *
-     * @return array
+     * @return array<int, string|null>
      */
-    public function hosts()
+    public function hosts(): array
     {
         return [
             $this->allSubdomainsOfApplicationUrl(),

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,7 +10,7 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array|string|null
+     * @var array<mixed>|string|null
      */
     protected $proxies;
 

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -9,9 +9,8 @@ class VerifyCsrfToken extends Middleware
     /**
      * The URIs that should be excluded from CSRF verification.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
-        //
     ];
 }

--- a/app/Http/Transformers/RecordTransformer.php
+++ b/app/Http/Transformers/RecordTransformer.php
@@ -9,9 +9,9 @@ class RecordTransformer implements RecordTransformerContract
     /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {
@@ -21,9 +21,9 @@ class RecordTransformer implements RecordTransformerContract
     /**
      * Transforms a collection of records to standardize the output.
      *
-     * @param array $collection The collection of records to be transformed
+     * @param array<int, array<string, mixed>> $collection The collection of records to be transformed
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function transformCollection(array $collection): array
     {

--- a/app/Http/Transformers/V0/ElementTransformer.php
+++ b/app/Http/Transformers/V0/ElementTransformer.php
@@ -9,9 +9,9 @@ class ElementTransformer extends RecordTransformer
     /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {

--- a/app/Http/Transformers/V0/SeedRankTransformer.php
+++ b/app/Http/Transformers/V0/SeedRankTransformer.php
@@ -9,9 +9,9 @@ class SeedRankTransformer extends RecordTransformer
     /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {

--- a/app/Http/Transformers/V0/SeedTestTransformer.php
+++ b/app/Http/Transformers/V0/SeedTestTransformer.php
@@ -7,18 +7,11 @@ use App\Http\Transformers\RecordTransformer;
 class SeedTestTransformer extends RecordTransformer
 {
     /**
-     * Instance of the TestQuestionTransformer.
-     *
-     * @var TestQuestionTransformer
-     */
-    protected $testQuestionTransformer;
-
-    /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {
@@ -37,18 +30,12 @@ class SeedTestTransformer extends RecordTransformer
     }
 
     /**
-     * Get the instance of the TestQuestionTransformer.
-     *
-     * If an existing instance does not exist, a new instance will be created.
+     * Create a new TestQuestionTransformer instance.
      *
      * @return TestQuestionTransformer
      */
     protected function getTestQuestionTransformer(): TestQuestionTransformer
     {
-        if (! $this->testQuestionTransformer) {
-            $this->testQuestionTransformer = new TestQuestionTransformer();
-        }
-
-        return $this->testQuestionTransformer;
+        return new TestQuestionTransformer();
     }
 }

--- a/app/Http/Transformers/V0/StatTransformer.php
+++ b/app/Http/Transformers/V0/StatTransformer.php
@@ -9,9 +9,9 @@ class StatTransformer extends RecordTransformer
     /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {

--- a/app/Http/Transformers/V0/StatusEffectTransformer.php
+++ b/app/Http/Transformers/V0/StatusEffectTransformer.php
@@ -9,9 +9,9 @@ class StatusEffectTransformer extends RecordTransformer
     /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {

--- a/app/Http/Transformers/V0/TestQuestionTransformer.php
+++ b/app/Http/Transformers/V0/TestQuestionTransformer.php
@@ -7,18 +7,11 @@ use App\Http\Transformers\RecordTransformer;
 class TestQuestionTransformer extends RecordTransformer
 {
     /**
-     * Instance of the SeedTestTransformer.
-     *
-     * @var SeedTestTransformer
-     */
-    protected $seedTestTransformer;
-
-    /**
      * Transforms an individual record to standardize the output.
      *
-     * @param array $record The record to be transformed
+     * @param array<string, mixed> $record The record to be transformed
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function transformRecord(array $record): array
     {
@@ -41,18 +34,12 @@ class TestQuestionTransformer extends RecordTransformer
     }
 
     /**
-     * Get the instance of the SeedTestTransformer.
-     *
-     * If an existing instance does not exist, a new instance will be created.
+     * Create a new SeedTestTransformer instance.
      *
      * @return SeedTestTransformer
      */
     protected function getSeedTestTransformer(): SeedTestTransformer
     {
-        if (! $this->seedTestTransformer) {
-            $this->seedTestTransformer = new SeedTestTransformer();
-        }
-
-        return $this->seedTestTransformer;
+        return new SeedTestTransformer();
     }
 }

--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -32,7 +32,7 @@ class Element extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [
         'id',
@@ -43,7 +43,7 @@ class Element extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'id'      => 'string',
@@ -54,7 +54,7 @@ class Element extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [
         'name',
@@ -63,7 +63,7 @@ class Element extends Model
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [
         'name',

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -41,14 +41,14 @@ class Model extends EloquentModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [];
 
     /**
      * The attributes that should be hidden for arrays.
      *
-     * @var array
+     * @var string[]
      */
     protected $hidden = [
         'created_at',

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -32,7 +32,7 @@ class SeedRank extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [
         'id',
@@ -43,7 +43,7 @@ class SeedRank extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'id'     => 'string',
@@ -54,7 +54,7 @@ class SeedRank extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [
         'rank',
@@ -64,7 +64,7 @@ class SeedRank extends Model
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [
         'rank',

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -33,7 +33,7 @@ class SeedTest extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [
         'id',
@@ -44,7 +44,7 @@ class SeedTest extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'id'    => 'string',
@@ -54,7 +54,7 @@ class SeedTest extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [
         'level',
@@ -63,7 +63,7 @@ class SeedTest extends Model
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [
         'level',
@@ -72,7 +72,7 @@ class SeedTest extends Model
     /**
      * The relations that are available to include with the resource.
      *
-     * @var array
+     * @var string[]
      */
     protected $availableIncludes = [
         'testQuestions',
@@ -81,7 +81,7 @@ class SeedTest extends Model
     /**
      * The default relations to include with the resource.
      *
-     * @var array
+     * @var string[]
      */
     protected $defaultIncludes = [];
 
@@ -98,7 +98,7 @@ class SeedTest extends Model
     /**
      * The Test Questions that are associated with the record.
      *
-     * @return HasMany
+     * @return HasMany<TestQuestion>
      */
     public function testQuestions(): HasMany
     {

--- a/app/Models/Stat.php
+++ b/app/Models/Stat.php
@@ -32,7 +32,7 @@ class Stat extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [
         'id',
@@ -44,7 +44,7 @@ class Stat extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'id'           => 'string',
@@ -56,14 +56,14 @@ class Stat extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [];
 
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [];
 }

--- a/app/Models/StatusEffect.php
+++ b/app/Models/StatusEffect.php
@@ -32,7 +32,7 @@ class StatusEffect extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [
         'id',
@@ -45,7 +45,7 @@ class StatusEffect extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'id'          => 'string',
@@ -58,7 +58,7 @@ class StatusEffect extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [
         'name',
@@ -69,7 +69,7 @@ class StatusEffect extends Model
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [
         'name',

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -33,7 +33,7 @@ class TestQuestion extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [
         'id',
@@ -48,7 +48,7 @@ class TestQuestion extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'id'              => 'string',
@@ -62,7 +62,7 @@ class TestQuestion extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [
         'question_number',
@@ -73,7 +73,7 @@ class TestQuestion extends Model
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [
         'question_number',
@@ -84,7 +84,7 @@ class TestQuestion extends Model
     /**
      * The relations that are available to include with the resource.
      *
-     * @var array
+     * @var string[]
      */
     protected $availableIncludes = [
         'seedTest',
@@ -93,7 +93,7 @@ class TestQuestion extends Model
     /**
      * The default relations to include with the resource.
      *
-     * @var array
+     * @var string[]
      */
     protected $defaultIncludes = [];
 
@@ -110,7 +110,7 @@ class TestQuestion extends Model
     /**
      * The SeeD Test that the record belongs to.
      *
-     * @return BelongsTo
+     * @return BelongsTo<SeedTest, TestQuestion>
      */
     public function seedTest(): BelongsTo
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,19 +2,19 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable;
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name',
@@ -25,7 +25,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for arrays.
      *
-     * @var array
+     * @var string[]
      */
     protected $hidden = [
         'password',
@@ -35,7 +35,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var string[]
      */
     protected $casts = [
         'email_verified_at' => 'datetime',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,10 +9,8 @@ class AppServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->bind(
             \App\Contracts\Services\SeedRankService::class,
@@ -44,10 +42,8 @@ class AppServiceProvider extends ServiceProvider
 
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,14 +3,13 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
     /**
      * The policy mappings for the application.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
@@ -18,13 +17,9 @@ class AuthServiceProvider extends ServiceProvider
 
     /**
      * Register any authentication / authorization services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->registerPolicies();
-
-        //
     }
 }

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -9,10 +9,8 @@ class BroadcastServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         Broadcast::routes();
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -12,7 +12,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The event listener mappings for the application.
      *
-     * @var array
+     * @var array<string, string[]>
      */
     protected $listen = [
         Registered::class => [
@@ -22,11 +22,8 @@ class EventServiceProvider extends ServiceProvider
 
     /**
      * Register any events for your application.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
-        //
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -20,20 +20,9 @@ class RouteServiceProvider extends ServiceProvider
     public const HOME = '/home';
 
     /**
-     * The controller namespace for the application.
-     *
-     * When present, controller route declarations will automatically be prefixed with this namespace.
-     *
-     * @var string|null
-     */
-    // protected $namespace = 'App\\Http\\Controllers';
-
-    /**
      * Define your route model bindings, pattern filters, etc.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->configureRateLimiting();
 
@@ -55,10 +44,8 @@ class RouteServiceProvider extends ServiceProvider
 
     /**
      * Configure the rate limiters for the application.
-     *
-     * @return void
      */
-    protected function configureRateLimiting()
+    protected function configureRateLimiting(): void
     {
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());

--- a/app/Scopes/OrderQueryResults.php
+++ b/app/Scopes/OrderQueryResults.php
@@ -11,11 +11,19 @@ class OrderQueryResults implements Scope
     /**
      * Order the query results by what is configured on the model.
      *
-     * @param Builder $builder The instance of the Eloquent query builder
-     * @param Model   $model   The instance of the current model
+     * @param Builder<Model> $builder The instance of the Eloquent query builder
+     * @param Model          $model   The instance of the current model
      */
-    public function apply(Builder $builder, Model $model)
+    public function apply(Builder $builder, Model $model): void
     {
-        $builder->orderBy($model->getOrderByField(), $model->getOrderByDirection());
+        if (
+            method_exists($model, 'getOrderByField') &&
+            method_exists($model, 'getOrderByDirection')
+        ) {
+            $builder->orderBy(
+                $model->getOrderByField(),
+                $model->getOrderByDirection()
+            );
+        }
     }
 }

--- a/app/Services/ModelService.php
+++ b/app/Services/ModelService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Contracts\Services\ModelService as ModelServiceContract;
 use App\Models\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -21,11 +22,11 @@ class ModelService implements ModelServiceContract
      *
      * @param Request $request The HTTP request from the client
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     public function all(Request $request): array
     {
-        $query = $this->model->newQuery();
+        $query = $this->getNewQueryBuilderInstance();
 
         if ($request->has('search')) {
             $query->search($request->search);
@@ -36,7 +37,7 @@ class ModelService implements ModelServiceContract
         );
 
         $results = $query->with($includes)
-            ->filter($request->query())
+            ->filter((array) $request->query())
             ->get();
 
         return $results->toArray();
@@ -50,7 +51,7 @@ class ModelService implements ModelServiceContract
      *
      * @throws NotFoundHttpException
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function findOrFail(string $id, Request $request): array
     {
@@ -69,5 +70,15 @@ class ModelService implements ModelServiceContract
         }
 
         return $data->toArray();
+    }
+
+    /**
+     * Create a new query builder instance.
+     *
+     * @return Builder<Model>
+     */
+    protected function getNewQueryBuilderInstance(): Builder
+    {
+        return $this->model->newQuery();
     }
 }

--- a/app/Traits/FiltersRecordsByFields.php
+++ b/app/Traits/FiltersRecordsByFields.php
@@ -3,20 +3,21 @@
 namespace App\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 trait FiltersRecordsByFields
 {
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @var string[]
      */
     protected $filterableFields = [];
 
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @return array
+     * @return string[]
      */
     public function getFilterableFields(): array
     {
@@ -26,10 +27,10 @@ trait FiltersRecordsByFields
     /**
      * Filter the records by the given criteria.
      *
-     * @param Builder $query   The Eloquent Query Builder instance
-     * @param array   $filters An array of `key => value` pairs that correspond to `column => filter`
+     * @param Builder<Model>       $query   The Eloquent Query Builder instance
+     * @param array<string, mixed> $filters An array of `key => value` pairs that correspond to `column => filter`
      *
-     * @return Builder
+     * @return Builder<Model>
      */
     public function scopeFilter(Builder $query, array $filters): Builder
     {

--- a/app/Traits/LoadsRelationsThroughServices.php
+++ b/app/Traits/LoadsRelationsThroughServices.php
@@ -2,7 +2,7 @@
 
 namespace App\Traits;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\Model;
 use Illuminate\Support\Str;
 
 trait LoadsRelationsThroughServices
@@ -10,21 +10,21 @@ trait LoadsRelationsThroughServices
     /**
      * The relations that are available to include with the resource.
      *
-     * @var array
+     * @var string[]
      */
     protected $availableIncludes = [];
 
     /**
      * The default relations to include with the resource.
      *
-     * @var array
+     * @var string[]
      */
     protected $defaultIncludes = [];
 
     /**
      * Get the relations that are available to include with the resource.
      *
-     * @return array
+     * @return string[]
      */
     public function getAvailableIncludes(): array
     {
@@ -34,7 +34,7 @@ trait LoadsRelationsThroughServices
     /**
      * Get the default relations to include with the resource.
      *
-     * @return array
+     * @return string[]
      */
     public function getDefaultIncludes(): array
     {
@@ -49,7 +49,7 @@ trait LoadsRelationsThroughServices
      *
      * @param string $includes The requested includes in csv format
      *
-     * @return array
+     * @return string[]
      */
     public function parseIncludes(string $includes): array
     {

--- a/app/Traits/OrdersQueryResults.php
+++ b/app/Traits/OrdersQueryResults.php
@@ -27,7 +27,7 @@ trait OrdersQueryResults
      */
     public function getOrderByField(): string
     {
-        return $this->orderByField ?: $this->getKeyName;
+        return $this->orderByField ?: $this->getKeyName();
     }
 
     /**
@@ -43,7 +43,7 @@ trait OrdersQueryResults
     /**
      * Bootstrap the trait on the model.
      */
-    protected static function bootOrdersQueryResults()
+    protected static function bootOrdersQueryResults(): void
     {
         static::addGlobalScope(new OrderQueryResults());
     }

--- a/app/Traits/Searchable.php
+++ b/app/Traits/Searchable.php
@@ -3,20 +3,21 @@
 namespace App\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 trait Searchable
 {
     /**
      * The fields that should be searchable.
      *
-     * @var array
+     * @var string[]
      */
     protected $searchableFields = [];
 
     /**
      * Get the fields that should be searchable.
      *
-     * @return array
+     * @return string[]
      */
     public function getSearchableFields(): array
     {
@@ -26,10 +27,10 @@ trait Searchable
     /**
      * Search the columns defined on the model for the specified value.
      *
-     * @param Builder $query The Eloquent Query Builder instance
-     * @param mixed   $value The value to search for on the columns
+     * @param Builder<Model> $query The Eloquent Query Builder instance
+     * @param mixed          $value The value to search for on the columns
      *
-     * @return Builder
+     * @return Builder<Model>
      */
     public function scopeSearch(Builder $query, mixed $value): Builder
     {

--- a/app/Traits/Uuids.php
+++ b/app/Traits/Uuids.php
@@ -2,6 +2,7 @@
 
 namespace App\Traits;
 
+use App\Models\Model;
 use Webpatser\Uuid\Uuid;
 
 trait Uuids
@@ -11,12 +12,12 @@ trait Uuids
      */
     protected static function bootUuids(): void
     {
-        static::creating(function (\App\Models\Model $model) {
+        static::creating(function (Model $model) {
             $model->{$model->getKeyName()} = Uuid::generate(4)->string;
         });
 
         // Prevent attempts to change a record's ID.
-        static::saving(function (\App\Models\Model $model) {
+        static::saving(function (Model $model) {
             $originalUuid = $model->getOriginal($model->getKeyName());
 
             if ($originalUuid !== $model->{$model->getKeyName()}) {

--- a/app/Traits/Uuids.php
+++ b/app/Traits/Uuids.php
@@ -9,14 +9,14 @@ trait Uuids
     /**
      * Bootstrap the trait on the model.
      */
-    protected static function bootUuids()
+    protected static function bootUuids(): void
     {
-        static::creating(function ($model) {
+        static::creating(function (\App\Models\Model $model) {
             $model->{$model->getKeyName()} = Uuid::generate(4)->string;
         });
 
         // Prevent attempts to change a record's ID.
-        static::saving(function ($model) {
+        static::saving(function (\App\Models\Model $model) {
             $originalUuid = $model->getOriginal($model->getKeyName());
 
             if ($originalUuid !== $model->{$model->getKeyName()}) {

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,12 @@
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",
-        "spatie/laravel-ignition": "^1.0",
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^6.1",
-        "phpunit/phpunit": "^9.5.10"
+        "nunomaduro/larastan": "^2.1",
+        "phpunit/phpunit": "^9.5.10",
+        "spatie/laravel-ignition": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -46,7 +47,10 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
-        ]
+        ],
+        "test": "vendor/bin/phpunit",
+        "test:report": "vendor/bin/phpunit --coverage-html reports/",
+        "phpstan": "vendor/bin/phpstan"
     },
     "extra": {
         "laravel": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bda0ff7b7792d2dd7cf578bdf1c5904d",
+    "content-hash": "593578038df926dc56616021a5960dd3",
     "packages": [
         {
             "name": "brick/math",
@@ -1157,16 +1157,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.3.1",
+            "version": "v9.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c1c4404511b83fbf90ccbcdf864d4a85537f35e4"
+                "reference": "29f0aaade82eadd20ef881b4efb88b0dad4e9a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c1c4404511b83fbf90ccbcdf864d4a85537f35e4",
-                "reference": "c1c4404511b83fbf90ccbcdf864d4a85537f35e4",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/29f0aaade82eadd20ef881b4efb88b0dad4e9a5b",
+                "reference": "29f0aaade82eadd20ef881b4efb88b0dad4e9a5b",
                 "shasum": ""
             },
             "require": {
@@ -1332,7 +1332,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-03-03T15:15:10+00:00"
+            "time": "2022-03-08T16:17:00+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -6267,16 +6267,16 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "9bd89e83cecdf8c37b64909454249eaed98b2c89"
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/9bd89e83cecdf8c37b64909454249eaed98b2c89",
-                "reference": "9bd89e83cecdf8c37b64909454249eaed98b2c89",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743",
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743",
                 "shasum": ""
             },
             "require": {
@@ -6313,7 +6313,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.0"
+                "source": "https://github.com/voku/portable-ascii/tree/2.0.1"
             },
             "funding": [
                 {
@@ -6337,7 +6337,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-24T18:59:03+00:00"
+            "time": "2022-03-08T17:03:00+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -6457,6 +6457,77 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "composer/pcre",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T20:21:48+00:00"
+        },
         {
             "name": "dms/phpunit-arraysubset-asserts",
             "version": "v0.4.0",
@@ -7033,6 +7104,104 @@
             "time": "2022-01-18T17:49:08+00:00"
         },
         {
+            "name": "nunomaduro/larastan",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/larastan.git",
+                "reference": "fa598dbc2b319673857ee17f6afe1aed6564b505"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/fa598dbc2b319673857ee17f6afe1aed6564b505",
+                "reference": "fa598dbc2b319673857ee17f6afe1aed6564b505",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^3.0",
+                "ext-json": "*",
+                "illuminate/console": "^9",
+                "illuminate/container": "^9",
+                "illuminate/contracts": "^9",
+                "illuminate/database": "^9",
+                "illuminate/http": "^9",
+                "illuminate/pipeline": "^9",
+                "illuminate/support": "^9",
+                "mockery/mockery": "^1.4.4",
+                "php": "^8.0.2",
+                "phpmyadmin/sql-parser": "^5.5",
+                "phpstan/phpstan": "^1.4.7"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.2",
+                "orchestra/testbench": "^7.0.0",
+                "phpunit/phpunit": "^9.5.11"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NunoMaduro\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/larastan/issues",
+                "source": "https://github.com/nunomaduro/larastan/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2022-03-08T10:00:28+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.3",
             "source": {
@@ -7304,6 +7473,79 @@
             "time": "2022-01-04T19:58:01+00:00"
         },
         {
+            "name": "phpmyadmin/sql-parser",
+            "version": "5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmyadmin/sql-parser.git",
+                "reference": "8ab99cd0007d880f49f5aa1807033dbfa21b1cb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/8ab99cd0007d880f49f5aa1807033dbfa21b1cb5",
+                "reference": "8ab99cd0007d880f49f5aa1807033dbfa21b1cb5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "conflict": {
+                "phpmyadmin/motranslator": "<3.0"
+            },
+            "require-dev": {
+                "phpmyadmin/coding-standard": "^3.0",
+                "phpmyadmin/motranslator": "^4.0 || ^5.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/php-code-coverage": "*",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.11",
+                "zumba/json-serializer": "^3.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
+            },
+            "bin": [
+                "bin/highlight-query",
+                "bin/lint-query",
+                "bin/tokenize-query"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMyAdmin\\SqlParser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The phpMyAdmin Team",
+                    "email": "developers@phpmyadmin.net",
+                    "homepage": "https://www.phpmyadmin.net/team/"
+                }
+            ],
+            "description": "A validating SQL lexer and parser with a focus on MySQL dialect.",
+            "homepage": "https://github.com/phpmyadmin/sql-parser",
+            "keywords": [
+                "analysis",
+                "lexer",
+                "parser",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/phpmyadmin/sql-parser/issues",
+                "source": "https://github.com/phpmyadmin/sql-parser"
+            },
+            "time": "2021-12-09T04:31:52+00:00"
+        },
+        {
             "name": "phpspec/prophecy",
             "version": "v1.15.0",
             "source": {
@@ -7371,17 +7613,81 @@
             "time": "2021-12-08T12:19:24+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.14",
+            "name": "phpstan/phpstan",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9f4d60b6afe5546421462b76cd4e633ebc364ab4"
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "1a45f44d319cf000a8c960af6b7435741e944771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f4d60b6afe5546421462b76cd4e633ebc364ab4",
-                "reference": "9f4d60b6afe5546421462b76cd4e633ebc364ab4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1a45f44d319cf000a8c960af6b7435741e944771",
+                "reference": "1a45f44d319cf000a8c960af6b7435741e944771",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-10T08:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
@@ -7437,7 +7743,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -7445,7 +7751,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-28T12:38:02+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -7690,16 +7996,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.17",
+            "version": "9.5.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5c5abcfaa2cbd44b2203995d7a339ef910fe0c8f"
+                "reference": "1b5856028273bfd855e60a887278857d872ec67a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5c5abcfaa2cbd44b2203995d7a339ef910fe0c8f",
-                "reference": "5c5abcfaa2cbd44b2203995d7a339ef910fe0c8f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1b5856028273bfd855e60a887278857d872ec67a",
+                "reference": "1b5856028273bfd855e60a887278857d872ec67a",
                 "shasum": ""
             },
             "require": {
@@ -7777,7 +8083,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.18"
             },
             "funding": [
                 {
@@ -7789,7 +8095,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-05T16:54:31+00:00"
+            "time": "2022-03-08T06:52:28+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -8883,16 +9189,16 @@
         },
         {
             "name": "spatie/ignition",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/ignition.git",
-                "reference": "090518ff676e17a038dfe77490018363ff66af20"
+                "reference": "ab8d1f938d3ffd20af25ad788a9d019e1123068c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/ignition/zipball/090518ff676e17a038dfe77490018363ff66af20",
-                "reference": "090518ff676e17a038dfe77490018363ff66af20",
+                "url": "https://api.github.com/repos/spatie/ignition/zipball/ab8d1f938d3ffd20af25ad788a9d019e1123068c",
+                "reference": "ab8d1f938d3ffd20af25ad788a9d019e1123068c",
                 "shasum": ""
             },
             "require": {
@@ -8950,20 +9256,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-04T12:52:17+00:00"
+            "time": "2022-03-08T15:12:58+00:00"
         },
         {
             "name": "spatie/laravel-ignition",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-ignition.git",
-                "reference": "d349854331789aba9205fd755e0c1d1934ef1463"
+                "reference": "ea3a5401b631e8a2ce10581c1fec10c240b8e36e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-ignition/zipball/d349854331789aba9205fd755e0c1d1934ef1463",
-                "reference": "d349854331789aba9205fd755e0c1d1934ef1463",
+                "url": "https://api.github.com/repos/spatie/laravel-ignition/zipball/ea3a5401b631e8a2ce10581c1fec10c240b8e36e",
+                "reference": "ea3a5401b631e8a2ce10581c1fec10c240b8e36e",
                 "shasum": ""
             },
             "require": {
@@ -9037,7 +9343,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T11:02:15+00:00"
+            "time": "2022-03-10T12:29:54+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/database/factories/ElementFactory.php
+++ b/database/factories/ElementFactory.php
@@ -5,6 +5,9 @@ namespace Database\Factories;
 use App\Models\Element;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Element>
+ */
 class ElementFactory extends Factory
 {
     /**

--- a/database/factories/SeedRankFactory.php
+++ b/database/factories/SeedRankFactory.php
@@ -5,6 +5,9 @@ namespace Database\Factories;
 use App\Models\SeedRank;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<SeedRank>
+ */
 class SeedRankFactory extends Factory
 {
     /**

--- a/database/factories/SeedTestFactory.php
+++ b/database/factories/SeedTestFactory.php
@@ -5,6 +5,9 @@ namespace Database\Factories;
 use App\Models\SeedTest;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<SeedTest>
+ */
 class SeedTestFactory extends Factory
 {
     /**

--- a/database/factories/StatFactory.php
+++ b/database/factories/StatFactory.php
@@ -5,6 +5,9 @@ namespace Database\Factories;
 use App\Models\Stat;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Stat>
+ */
 class StatFactory extends Factory
 {
     /**

--- a/database/factories/StatusEffectFactory.php
+++ b/database/factories/StatusEffectFactory.php
@@ -5,6 +5,9 @@ namespace Database\Factories;
 use App\Models\StatusEffect;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<StatusEffect>
+ */
 class StatusEffectFactory extends Factory
 {
     /**

--- a/database/factories/TestQuestionFactory.php
+++ b/database/factories/TestQuestionFactory.php
@@ -5,6 +5,9 @@ namespace Database\Factories;
 use App\Models\TestQuestion;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<TestQuestion>
+ */
 class TestQuestionFactory extends Factory
 {
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -6,6 +6,9 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
+/**
+ * @extends Factory<User>
+ */
 class UserFactory extends Factory
 {
     /**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+parameters:
+  paths:
+      - app
+      - tests
+  level: 8
+  ignoreErrors:
+    # This is thrown when creating an instance of a model using factories. Since we know what the instance is, we can ignore these errors.
+    - '#Access to an undefined property [a-zA-Z0-9\\_]+\|Illuminate\\Database\\Eloquent\\Collection<int, [a-zA-Z0-9\\_]+>::\$[a-zA-Z0-9\\_]+#'
+    # This is thrown when creating an instance of a model using factories. Since we know what the instance is, we can ignore these errors.
+    - '#Call to an undefined method [a-zA-Z0-9\\_]+\|Illuminate\\Database\\Eloquent\\Collection<int, [a-zA-Z0-9\\_]+>::[a-zA-Z0-9\\_]+()#'
+  excludePaths:
+includes:
+  - ./vendor/nunomaduro/larastan/extension.neon

--- a/tests/Feature/Endpoints/V0/ElementEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/ElementEndpointTest.php
@@ -11,9 +11,9 @@ class ElementEndpointTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_elements()
+    public function it_will_return_a_list_of_elements(): void
     {
-        $elements = Element::factory()->count(8)->create();
+        Element::factory()->count(8)->create();
 
         $response = $this->get('/v0/elements');
 
@@ -33,11 +33,11 @@ class ElementEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_element_using_the_id_key()
+    public function it_will_return_an_individual_element_using_the_id_key(): void
     {
-        $element = Element::factory()->create();
+        $element = Element::factory()->create()->toArray();
 
-        $response = $this->get("/v0/elements/{$element->id}");
+        $response = $this->get("/v0/elements/{$element['id']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -45,19 +45,19 @@ class ElementEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $element->id,
-                'sort_id' => $element->sort_id,
-                'name' => $element->name,
+                'id' => $element['id'],
+                'sort_id' => $element['sort_id'],
+                'name' => $element['name'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_return_an_individual_element_using_the_name_key()
+    public function it_will_return_an_individual_element_using_the_name_key(): void
     {
-        $element = Element::factory()->create();
+        $element = Element::factory()->create()->toArray();
 
-        $response = $this->get("/v0/elements/{$element->name}");
+        $response = $this->get("/v0/elements/{$element['name']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -65,15 +65,15 @@ class ElementEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $element->id,
-                'sort_id' => $element->sort_id,
-                'name' => $element->name,
+                'id' => $element['id'],
+                'sort_id' => $element['sort_id'],
+                'name' => $element['name'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $response = $this->get('/v0/elements/invalid');
 
@@ -89,11 +89,11 @@ class ElementEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_elements_via_the_name_column()
+    public function it_can_search_for_elements_via_the_name_column(): void
     {
         Element::factory()->create(['sort_id' => 1, 'name' => 'fire']);
-        $two = Element::factory()->create(['sort_id' => 3, 'name' => 'thunder']);
-        $three = Element::factory()->create(['sort_id' => 7, 'name' => 'water']);
+        $two = Element::factory()->create(['sort_id' => 3, 'name' => 'thunder'])->toArray();
+        $three = Element::factory()->create(['sort_id' => 7, 'name' => 'water'])->toArray();
 
         $response = $this->get('/v0/elements?search=er');
 
@@ -104,23 +104,23 @@ class ElementEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'name' => $three->name,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'name' => $three['name'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_elements_via_the_name_column()
+    public function it_can_filter_elements_via_the_name_column(): void
     {
-        $one = Element::factory()->create(['sort_id' => 1, 'name' => 'fire']);
+        $one = Element::factory()->create(['sort_id' => 1, 'name' => 'fire'])->toArray();
         Element::factory()->create(['sort_id' => 3, 'name' => 'thunder']);
         Element::factory()->create(['sort_id' => 7, 'name' => 'water']);
 
@@ -133,20 +133,20 @@ class ElementEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_elements_via_the_name_column_using_the_like_statement()
+    public function it_can_filter_elements_via_the_name_column_using_the_like_statement(): void
     {
         Element::factory()->create(['sort_id' => 1, 'name' => 'fire']);
-        $two = Element::factory()->create(['sort_id' => 3, 'name' => 'thunder']);
-        $three = Element::factory()->create(['sort_id' => 7, 'name' => 'water']);
+        $two = Element::factory()->create(['sort_id' => 3, 'name' => 'thunder'])->toArray();
+        $three = Element::factory()->create(['sort_id' => 7, 'name' => 'water'])->toArray();
 
         $response = $this->get('/v0/elements?name=like:er');
 
@@ -157,14 +157,14 @@ class ElementEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'name' => $three->name,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'name' => $three['name'],
                 ],
             ],
         ]);

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 class HealthCheckEndpointTest extends TestCase
 {
     /** @test */
-    public function it_can_check_the_server_status()
+    public function it_can_check_the_server_status(): void
     {
         $this->withoutMiddleware();
 

--- a/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
@@ -11,9 +11,9 @@ class SeedRankEndpointTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_seed_ranks()
+    public function it_will_return_a_list_of_seed_ranks(): void
     {
-        $seedRanks = SeedRank::factory()->count(10)->create();
+        SeedRank::factory()->count(10)->create();
 
         $response = $this->get('/v0/seed-ranks');
 
@@ -33,11 +33,11 @@ class SeedRankEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_rank_using_the_id_key()
+    public function it_will_return_an_individual_seed_rank_using_the_id_key(): void
     {
-        $seedRank = SeedRank::factory()->create();
+        $seedRank = SeedRank::factory()->create()->toArray();
 
-        $response = $this->get("/v0/seed-ranks/{$seedRank->id}");
+        $response = $this->get("/v0/seed-ranks/{$seedRank['id']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -45,19 +45,19 @@ class SeedRankEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedRank->id,
-                'rank' => $seedRank->rank,
-                'salary' => $seedRank->salary,
+                'id' => $seedRank['id'],
+                'rank' => $seedRank['rank'],
+                'salary' => $seedRank['salary'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_rank_using_the_rank_key()
+    public function it_will_return_an_individual_seed_rank_using_the_rank_key(): void
     {
-        $seedRank = SeedRank::factory()->create();
+        $seedRank = SeedRank::factory()->create()->toArray();
 
-        $response = $this->get("/v0/seed-ranks/{$seedRank->rank}");
+        $response = $this->get("/v0/seed-ranks/{$seedRank['rank']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -65,15 +65,15 @@ class SeedRankEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedRank->id,
-                'rank' => $seedRank->rank,
-                'salary' => $seedRank->salary,
+                'id' => $seedRank['id'],
+                'rank' => $seedRank['rank'],
+                'salary' => $seedRank['salary'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $response = $this->get('/v0/seed-ranks/invalid');
 
@@ -89,11 +89,11 @@ class SeedRankEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_seed_ranks_via_the_rank_column()
+    public function it_can_search_for_seed_ranks_via_the_rank_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000])->toArray();
 
         $response = $this->get('/v0/seed-ranks?search=1');
 
@@ -104,23 +104,23 @@ class SeedRankEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
                 [
-                    'id' => $three->id,
-                    'rank' => $three->rank,
-                    'salary' => $three->salary,
+                    'id' => $three['id'],
+                    'rank' => $three['rank'],
+                    'salary' => $three['salary'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_search_for_seed_ranks_via_the_salary_column()
+    public function it_can_search_for_seed_ranks_via_the_salary_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -133,18 +133,18 @@ class SeedRankEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_rank_column()
+    public function it_can_filter_seed_ranks_via_the_rank_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -157,20 +157,20 @@ class SeedRankEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement()
+    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000])->toArray();
 
         $response = $this->get('/v0/seed-ranks?rank=like:1');
 
@@ -181,23 +181,23 @@ class SeedRankEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
                 [
-                    'id' => $three->id,
-                    'rank' => $three->rank,
-                    'salary' => $three->salary,
+                    'id' => $three['id'],
+                    'rank' => $three['rank'],
+                    'salary' => $three['salary'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_salary_column()
+    public function it_can_filter_seed_ranks_via_the_salary_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -210,21 +210,21 @@ class SeedRankEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement()
+    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
-        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
+        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500])->toArray();
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
-        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000]);
+        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000])->toArray();
 
         $response = $this->get('/v0/seed-ranks?salary=like:500');
 
@@ -235,19 +235,19 @@ class SeedRankEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
                 [
-                    'id' => $two->id,
-                    'rank' => $two->rank,
-                    'salary' => $two->salary,
+                    'id' => $two['id'],
+                    'rank' => $two['rank'],
+                    'salary' => $two['salary'],
                 ],
                 [
-                    'id' => $four->id,
-                    'rank' => $four->rank,
-                    'salary' => $four->salary,
+                    'id' => $four['id'],
+                    'rank' => $four['rank'],
+                    'salary' => $four['salary'],
                 ],
             ],
         ]);

--- a/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
@@ -13,9 +13,9 @@ class SeedTestEndpointTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_seed_tests()
+    public function it_will_return_a_list_of_seed_tests(): void
     {
-        $seedTests = SeedTest::factory()->count(10)->create();
+        SeedTest::factory()->count(10)->create();
 
         $response = $this->get('/v0/seed-tests');
 
@@ -35,11 +35,11 @@ class SeedTestEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_test_using_the_id_key()
+    public function it_will_return_an_individual_seed_test_using_the_id_key(): void
     {
-        $seedTest = SeedTest::factory()->create();
+        $seedTest = SeedTest::factory()->create()->toArray();
 
-        $response = $this->get("/v0/seed-tests/{$seedTest->id}");
+        $response = $this->get("/v0/seed-tests/{$seedTest['id']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -47,18 +47,18 @@ class SeedTestEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedTest->id,
-                'level' => $seedTest->level,
+                'id' => $seedTest['id'],
+                'level' => $seedTest['level'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_test_using_the_level_key()
+    public function it_will_return_an_individual_seed_test_using_the_level_key(): void
     {
-        $seedTest = SeedTest::factory()->create();
+        $seedTest = SeedTest::factory()->create()->toArray();
 
-        $response = $this->get("/v0/seed-tests/{$seedTest->level}");
+        $response = $this->get("/v0/seed-tests/{$seedTest['level']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -66,14 +66,14 @@ class SeedTestEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedTest->id,
-                'level' => $seedTest->level,
+                'id' => $seedTest['id'],
+                'level' => $seedTest['level'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $response = $this->get('/v0/seed-tests/invalid');
 
@@ -89,11 +89,11 @@ class SeedTestEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_seed_tests_via_the_level_column()
+    public function it_can_search_for_seed_tests_via_the_level_column(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        $three = SeedTest::factory()->create(['level' => 10])->toArray();
 
         $response = $this->get('/v0/seed-tests?search=1');
 
@@ -104,21 +104,21 @@ class SeedTestEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'level' => $one->level,
+                    'id' => $one['id'],
+                    'level' => $one['level'],
                 ],
                 [
-                    'id' => $three->id,
-                    'level' => $three->level,
+                    'id' => $three['id'],
+                    'level' => $three['level'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_seed_tests_via_the_level_column()
+    public function it_can_filter_seed_tests_via_the_level_column(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
         SeedTest::factory()->create(['level' => 10]);
 
@@ -131,19 +131,19 @@ class SeedTestEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'level' => $one->level,
+                    'id' => $one['id'],
+                    'level' => $one['level'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement()
+    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        $three = SeedTest::factory()->create(['level' => 10])->toArray();
 
         $response = $this->get('/v0/seed-tests?level=like:1');
 
@@ -154,21 +154,21 @@ class SeedTestEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'level' => $one->level,
+                    'id' => $one['id'],
+                    'level' => $one['level'],
                 ],
                 [
-                    'id' => $three->id,
-                    'level' => $three->level,
+                    'id' => $three['id'],
+                    'level' => $three['level'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_load_the_test_questions_relation_on_a_list_of_seed_tests()
+    public function it_can_load_the_test_questions_relation_on_a_list_of_seed_tests(): void
     {
-        $seedTests = SeedTest::factory()
+        SeedTest::factory()
             ->count(10)
             ->has(TestQuestion::factory()->count(10))
             ->create();
@@ -197,14 +197,16 @@ class SeedTestEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_the_test_questions_relation_on_an_individual_seed_test()
+    public function it_can_load_the_test_questions_relation_on_an_individual_seed_test(): void
     {
         $seedTest = SeedTest::factory()
             ->has(TestQuestion::factory()->count(1))
-            ->create();
+            ->create()
+            ->load('testQuestions')
+            ->toArray();
 
         $testQuestionTransformer = $this->app->make(TestQuestionTransformer::class);
-        $response = $this->get("/v0/seed-tests/{$seedTest->id}?include=test-questions");
+        $response = $this->get("/v0/seed-tests/{$seedTest['id']}?include=test-questions");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -212,9 +214,9 @@ class SeedTestEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedTest->id,
-                'level' => $seedTest->level,
-                'test_questions' => $testQuestionTransformer->transformCollection($seedTest->testQuestions->toArray()),
+                'id' => $seedTest['id'],
+                'level' => $seedTest['level'],
+                'test_questions' => $testQuestionTransformer->transformCollection($seedTest['test_questions']),
             ],
         ]);
     }

--- a/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
@@ -11,9 +11,9 @@ class StatusEffectEndpointTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_status_effects()
+    public function it_will_return_a_list_of_status_effects(): void
     {
-        $statusEffects = StatusEffect::factory()->count(10)->create();
+        StatusEffect::factory()->count(10)->create();
 
         $response = $this->get('/v0/status-effects');
 
@@ -33,11 +33,11 @@ class StatusEffectEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_status_effect_using_the_id_key()
+    public function it_will_return_an_individual_status_effect_using_the_id_key(): void
     {
-        $statusEffect = StatusEffect::factory()->create();
+        $statusEffect = StatusEffect::factory()->create()->toArray();
 
-        $response = $this->get("/v0/status-effects/{$statusEffect->id}");
+        $response = $this->get("/v0/status-effects/{$statusEffect['id']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -45,21 +45,21 @@ class StatusEffectEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $statusEffect->id,
-                'sort_id' => $statusEffect->sort_id,
-                'name' => $statusEffect->name,
-                'type' => $statusEffect->type,
-                'description' => $statusEffect->description,
+                'id' => $statusEffect['id'],
+                'sort_id' => $statusEffect['sort_id'],
+                'name' => $statusEffect['name'],
+                'type' => $statusEffect['type'],
+                'description' => $statusEffect['description'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_return_an_individual_status_effect_using_the_name_key()
+    public function it_will_return_an_individual_status_effect_using_the_name_key(): void
     {
-        $statusEffect = StatusEffect::factory()->create();
+        $statusEffect = StatusEffect::factory()->create()->toArray();
 
-        $response = $this->get("/v0/status-effects/{$statusEffect->name}");
+        $response = $this->get("/v0/status-effects/{$statusEffect['name']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -67,17 +67,17 @@ class StatusEffectEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $statusEffect->id,
-                'sort_id' => $statusEffect->sort_id,
-                'name' => $statusEffect->name,
-                'type' => $statusEffect->type,
-                'description' => $statusEffect->description,
+                'id' => $statusEffect['id'],
+                'sort_id' => $statusEffect['sort_id'],
+                'name' => $statusEffect['name'],
+                'type' => $statusEffect['type'],
+                'description' => $statusEffect['description'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $response = $this->get('/v0/status-effects/invalid');
 
@@ -93,11 +93,23 @@ class StatusEffectEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_status_effects_via_the_name_column()
+    public function it_can_search_for_status_effects_via_the_name_column(): void
     {
-        StatusEffect::factory()->create(['sort_id' => 1, 'name' => 'sleep', 'type' => 'harmful']);
-        $two = StatusEffect::factory()->create(['sort_id' => 2, 'name' => 'slow', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 3, 'name' => 'haste', 'type' => 'beneficial']);
+        StatusEffect::factory()->create([
+            'sort_id' => 1,
+            'name' => 'sleep',
+            'type' => 'harmful',
+        ]);
+        $two = StatusEffect::factory()->create([
+            'sort_id' => 2,
+            'name' => 'slow',
+            'type' => 'harmful',
+        ])->toArray();
+        StatusEffect::factory()->create([
+            'sort_id' => 3,
+            'name' => 'haste',
+            'type' => 'beneficial',
+        ]);
 
         $response = $this->get('/v0/status-effects?search=slow');
 
@@ -108,22 +120,34 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_search_for_status_effects_via_the_type_column()
+    public function it_can_search_for_status_effects_via_the_type_column(): void
     {
-        $one = StatusEffect::factory()->create(['sort_id' => 1, 'name' => 'sleep', 'type' => 'harmful']);
-        $two = StatusEffect::factory()->create(['sort_id' => 2, 'name' => 'slow', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 3, 'name' => 'haste', 'type' => 'beneficial']);
+        $one = StatusEffect::factory()->create([
+            'sort_id' => 1,
+            'name' => 'sleep',
+            'type' => 'harmful',
+        ])->toArray();
+        $two = StatusEffect::factory()->create([
+            'sort_id' => 2,
+            'name' => 'slow',
+            'type' => 'harmful',
+        ])->toArray();
+        StatusEffect::factory()->create([
+            'sort_id' => 3,
+            'name' => 'haste',
+            'type' => 'beneficial',
+        ]);
 
         $response = $this->get('/v0/status-effects?search=harmful');
 
@@ -134,25 +158,25 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_search_for_status_effects_via_the_description_column()
+    public function it_can_search_for_status_effects_via_the_description_column(): void
     {
         StatusEffect::factory()->create([
             'sort_id' => 1,
@@ -171,7 +195,7 @@ class StatusEffectEndpointTest extends TestCase
             'name' => 'haste',
             'type' => 'beneficial',
             'description' => 'Group Two',
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/status-effects?search=two');
 
@@ -182,22 +206,34 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'name' => $three->name,
-                    'type' => $three->type,
-                    'description' => $three->description,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'name' => $three['name'],
+                    'type' => $three['type'],
+                    'description' => $three['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_status_effects_via_the_name_column()
+    public function it_can_filter_status_effects_via_the_name_column(): void
     {
-        $one = StatusEffect::factory()->create(['sort_id' => 1, 'name' => 'sleep', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 2, 'name' => 'slow', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 3, 'name' => 'haste', 'type' => 'beneficial']);
+        $one = StatusEffect::factory()->create([
+            'sort_id' => 1,
+            'name' => 'sleep',
+            'type' => 'harmful',
+        ])->toArray();
+        StatusEffect::factory()->create([
+            'sort_id' => 2,
+            'name' => 'slow',
+            'type' => 'harmful',
+        ]);
+        StatusEffect::factory()->create([
+            'sort_id' => 3,
+            'name' => 'haste',
+            'type' => 'beneficial',
+        ]);
 
         $response = $this->get('/v0/status-effects?name=sleep');
 
@@ -208,22 +244,34 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_status_effects_via_the_name_column_using_the_like_statement()
+    public function it_can_filter_status_effects_via_the_name_column_using_the_like_statement(): void
     {
-        $one = StatusEffect::factory()->create(['sort_id' => 1, 'name' => 'sleep', 'type' => 'harmful']);
-        $two = StatusEffect::factory()->create(['sort_id' => 2, 'name' => 'slow', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 3, 'name' => 'haste', 'type' => 'beneficial']);
+        $one = StatusEffect::factory()->create([
+            'sort_id' => 1,
+            'name' => 'sleep',
+            'type' => 'harmful',
+        ])->toArray();
+        $two = StatusEffect::factory()->create([
+            'sort_id' => 2,
+            'name' => 'slow',
+            'type' => 'harmful',
+        ])->toArray();
+        StatusEffect::factory()->create([
+            'sort_id' => 3,
+            'name' => 'haste',
+            'type' => 'beneficial',
+        ]);
 
         $response = $this->get('/v0/status-effects?name=like:sl');
 
@@ -234,29 +282,41 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_status_effects_via_the_type_column()
+    public function it_can_filter_status_effects_via_the_type_column(): void
     {
-        $one = StatusEffect::factory()->create(['sort_id' => 1, 'name' => 'sleep', 'type' => 'harmful']);
-        $two = StatusEffect::factory()->create(['sort_id' => 2, 'name' => 'slow', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 3, 'name' => 'haste', 'type' => 'beneficial']);
+        $one = StatusEffect::factory()->create([
+            'sort_id' => 1,
+            'name' => 'sleep',
+            'type' => 'harmful',
+        ])->toArray();
+        $two = StatusEffect::factory()->create([
+            'sort_id' => 2,
+            'name' => 'slow',
+            'type' => 'harmful',
+        ])->toArray();
+        StatusEffect::factory()->create([
+            'sort_id' => 3,
+            'name' => 'haste',
+            'type' => 'beneficial',
+        ]);
 
         $response = $this->get('/v0/status-effects?type=harmful');
 
@@ -267,29 +327,41 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_status_effects_via_the_type_column_using_the_like_statement()
+    public function it_can_filter_status_effects_via_the_type_column_using_the_like_statement(): void
     {
-        $one = StatusEffect::factory()->create(['sort_id' => 1, 'name' => 'sleep', 'type' => 'harmful']);
-        $two = StatusEffect::factory()->create(['sort_id' => 2, 'name' => 'slow', 'type' => 'harmful']);
-        StatusEffect::factory()->create(['sort_id' => 3, 'name' => 'haste', 'type' => 'beneficial']);
+        $one = StatusEffect::factory()->create([
+            'sort_id' => 1,
+            'name' => 'sleep',
+            'type' => 'harmful',
+        ])->toArray();
+        $two = StatusEffect::factory()->create([
+            'sort_id' => 2,
+            'name' => 'slow',
+            'type' => 'harmful',
+        ])->toArray();
+        StatusEffect::factory()->create([
+            'sort_id' => 3,
+            'name' => 'haste',
+            'type' => 'beneficial',
+        ]);
 
         $response = $this->get('/v0/status-effects?type=like:harm');
 
@@ -300,38 +372,38 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_status_effects_via_the_description_column()
+    public function it_can_filter_status_effects_via_the_description_column(): void
     {
         $one = StatusEffect::factory()->create([
             'sort_id' => 1,
             'name' => 'sleep',
             'type' => 'harmful',
             'description' => 'Group One',
-        ]);
+        ])->toArray();
         $two = StatusEffect::factory()->create([
             'sort_id' => 2,
             'name' => 'slow',
             'type' => 'harmful',
             'description' => 'Group One',
-        ]);
+        ])->toArray();
         StatusEffect::factory()->create([
             'sort_id' => 3,
             'name' => 'haste',
@@ -348,38 +420,38 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_status_effects_via_the_description_column_using_the_like_statement()
+    public function it_can_filter_status_effects_via_the_description_column_using_the_like_statement(): void
     {
         $one = StatusEffect::factory()->create([
             'sort_id' => 1,
             'name' => 'sleep',
             'type' => 'harmful',
             'description' => 'Group One',
-        ]);
+        ])->toArray();
         $two = StatusEffect::factory()->create([
             'sort_id' => 2,
             'name' => 'slow',
             'type' => 'harmful',
             'description' => 'Group One',
-        ]);
+        ])->toArray();
         StatusEffect::factory()->create([
             'sort_id' => 3,
             'name' => 'haste',
@@ -396,18 +468,18 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'name' => $one->name,
-                    'type' => $one->type,
-                    'description' => $one->description,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'name' => $one['name'],
+                    'type' => $one['type'],
+                    'description' => $one['description'],
                 ],
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'name' => $two->name,
-                    'type' => $two->type,
-                    'description' => $two->description,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'name' => $two['name'],
+                    'type' => $two['type'],
+                    'description' => $two['description'],
                 ],
             ],
         ]);

--- a/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
@@ -13,9 +13,9 @@ class TestQuestionEndpointTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_test_questions()
+    public function it_will_return_a_list_of_test_questions(): void
     {
-        $testQuestions = TestQuestion::factory()->count(10)->create();
+        TestQuestion::factory()->count(10)->create();
 
         $response = $this->get('/v0/test-questions');
 
@@ -35,11 +35,11 @@ class TestQuestionEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_test_question_using_the_id_key()
+    public function it_will_return_an_individual_test_question_using_the_id_key(): void
     {
-        $testQuestion = TestQuestion::factory()->create();
+        $testQuestion = TestQuestion::factory()->create()->toArray();
 
-        $response = $this->get("/v0/test-questions/{$testQuestion->id}");
+        $response = $this->get("/v0/test-questions/{$testQuestion['id']}");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -47,18 +47,18 @@ class TestQuestionEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $testQuestion->id,
-                'sort_id' => $testQuestion->sort_id,
-                'seed_test_id' => $testQuestion->seed_test_id,
-                'question_number' => $testQuestion->question_number,
-                'question' => $testQuestion->question,
-                'answer' => $testQuestion->answer,
+                'id' => $testQuestion['id'],
+                'sort_id' => $testQuestion['sort_id'],
+                'seed_test_id' => $testQuestion['seed_test_id'],
+                'question_number' => $testQuestion['question_number'],
+                'question' => $testQuestion['question'],
+                'answer' => $testQuestion['answer'],
             ],
         ]);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $response = $this->get('/v0/test-questions/invalid');
 
@@ -74,14 +74,14 @@ class TestQuestionEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_question_number_column()
+    public function it_can_search_for_test_questions_via_the_question_number_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -92,7 +92,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/test-questions?search=1');
 
@@ -103,34 +103,34 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_question_column()
+    public function it_can_search_for_test_questions_via_the_question_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -142,7 +142,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/test-questions?search=can');
 
@@ -153,34 +153,34 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_answer_column()
+    public function it_can_search_for_test_questions_via_the_answer_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -192,7 +192,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/test-questions?search=false');
 
@@ -203,34 +203,34 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_number_column()
+    public function it_can_filter_test_questions_via_the_question_number_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -253,26 +253,26 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -284,7 +284,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/test-questions?question_number=like:1');
 
@@ -295,34 +295,34 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_column()
+    public function it_can_filter_test_questions_via_the_question_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -345,26 +345,26 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -376,7 +376,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/test-questions?question=like:can');
 
@@ -387,27 +387,27 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_answer_column()
+    public function it_can_filter_test_questions_via_the_answer_column(): void
     {
         TestQuestion::factory()->create([
             'sort_id' => 1,
@@ -420,7 +420,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 5,
             'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
             'answer' => true,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 3,
             'question_number' => 10,
@@ -437,26 +437,26 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'seed_test_id' => $two->seed_test_id,
-                    'question_number' => $two->question_number,
-                    'question' => $two->question,
-                    'answer' => $two->answer,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'seed_test_id' => $two['seed_test_id'],
+                    'question_number' => $two['question_number'],
+                    'question' => $two['question'],
+                    'answer' => $two['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -468,7 +468,7 @@ class TestQuestionEndpointTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $response = $this->get('/v0/test-questions?answer=like:f');
 
@@ -479,29 +479,29 @@ class TestQuestionEndpointTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ]);
     }
 
     /** @test */
-    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions()
+    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions(): void
     {
-        $testQuestions = TestQuestion::factory()
+        TestQuestion::factory()
             ->count(10)
             ->for(SeedTest::factory())
             ->create();
@@ -530,14 +530,16 @@ class TestQuestionEndpointTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_the_seed_test_relation_on_an_individual_test_question()
+    public function it_can_load_the_seed_test_relation_on_an_individual_test_question(): void
     {
         $testQuestion = TestQuestion::factory()
             ->for(SeedTest::factory())
-            ->create();
+            ->create()
+            ->load('seedTest')
+            ->toArray();
 
         $seedTestTransformer = $this->app->make(SeedTestTransformer::class);
-        $response = $this->get("/v0/test-questions/{$testQuestion->id}?include=seed-test");
+        $response = $this->get("/v0/test-questions/{$testQuestion['id']}?include=seed-test");
 
         $response->assertStatus(200);
         $response->assertExactJson([
@@ -545,13 +547,13 @@ class TestQuestionEndpointTest extends TestCase
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $testQuestion->id,
-                'sort_id' => $testQuestion->sort_id,
-                'seed_test_id' => $testQuestion->seed_test_id,
-                'question_number' => $testQuestion->question_number,
-                'question' => $testQuestion->question,
-                'answer' => $testQuestion->answer,
-                'seed_test' => $seedTestTransformer->transformRecord($testQuestion->seedTest->toArray()),
+                'id' => $testQuestion['id'],
+                'sort_id' => $testQuestion['sort_id'],
+                'seed_test_id' => $testQuestion['seed_test_id'],
+                'question_number' => $testQuestion['question_number'],
+                'question' => $testQuestion['question'],
+                'answer' => $testQuestion['answer'],
+                'seed_test' => $seedTestTransformer->transformRecord($testQuestion['seed_test']),
             ],
         ]);
     }

--- a/tests/Feature/Middleware/CaptureInboundRequestTest.php
+++ b/tests/Feature/Middleware/CaptureInboundRequestTest.php
@@ -12,7 +12,7 @@ class CaptureInboundRequestTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_capture_successful_requests()
+    public function it_will_capture_successful_requests(): void
     {
         $this->get('/v0/seed-ranks');
 
@@ -20,7 +20,7 @@ class CaptureInboundRequestTest extends TestCase
     }
 
     /** @test */
-    public function it_will_capture_unsuccessful_requests()
+    public function it_will_capture_unsuccessful_requests(): void
     {
         $mockedService = $this->mock(SeedRankService::class, function ($mock) {
             $mock->shouldReceive('all')->andThrow(new Exception('Something'));
@@ -33,7 +33,7 @@ class CaptureInboundRequestTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_capture_404_requests()
+    public function it_will_not_capture_404_requests(): void
     {
         $this->get('/invalid-endpoint');
 

--- a/tests/Unit/Controllers/V0/HealthCheckControllerTest.php
+++ b/tests/Unit/Controllers/V0/HealthCheckControllerTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 class HealthCheckControllerTest extends TestCase
 {
     /** @test */
-    public function it_can_check_the_server_status()
+    public function it_can_check_the_server_status(): void
     {
         $baseUrl = config('app.url');
         $currentApiVersion = config('app.current_api_version');

--- a/tests/Unit/Controllers/V0/SeedRankControllerTest.php
+++ b/tests/Unit/Controllers/V0/SeedRankControllerTest.php
@@ -16,9 +16,9 @@ class SeedRankControllerTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_seed_ranks()
+    public function it_will_return_a_list_of_seed_ranks(): void
     {
-        $seedRanks = SeedRank::factory()->count(10)->create();
+        SeedRank::factory()->count(10)->create();
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
@@ -35,53 +35,53 @@ class SeedRankControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_rank_using_the_id_key()
+    public function it_will_return_an_individual_seed_rank_using_the_id_key(): void
     {
-        $seedRank = SeedRank::factory()->create();
+        $seedRank = SeedRank::factory()->create()->toArray();
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
         $controller = new SeedRankController($service, $transformer);
 
-        $response = $controller->show(new Request(), $seedRank->id);
+        $response = $controller->show(new Request(), $seedRank['id']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedRank->id,
-                'rank' => $seedRank->rank,
-                'salary' => $seedRank->salary,
+                'id' => $seedRank['id'],
+                'rank' => $seedRank['rank'],
+                'salary' => $seedRank['salary'],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_rank_using_the_rank_key()
+    public function it_will_return_an_individual_seed_rank_using_the_rank_key(): void
     {
-        $seedRank = SeedRank::factory()->create();
+        $seedRank = SeedRank::factory()->create()->toArray();
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
         $controller = new SeedRankController($service, $transformer);
 
-        $response = $controller->show(new Request(), $seedRank->rank);
+        $response = $controller->show(new Request(), $seedRank['rank']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedRank->id,
-                'rank' => $seedRank->rank,
-                'salary' => $seedRank->salary,
+                'id' => $seedRank['id'],
+                'rank' => $seedRank['rank'],
+                'salary' => $seedRank['salary'],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -93,11 +93,11 @@ class SeedRankControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_seed_ranks_via_the_rank_column()
+    public function it_can_search_for_seed_ranks_via_the_rank_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000])->toArray();
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
@@ -111,23 +111,23 @@ class SeedRankControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
                 [
-                    'id' => $three->id,
-                    'rank' => $three->rank,
-                    'salary' => $three->salary,
+                    'id' => $three['id'],
+                    'rank' => $three['rank'],
+                    'salary' => $three['salary'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_search_for_seed_ranks_via_the_salary_column()
+    public function it_can_search_for_seed_ranks_via_the_salary_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -143,20 +143,20 @@ class SeedRankControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_rank_column()
+    public function it_can_filter_seed_ranks_via_the_rank_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
@@ -170,20 +170,20 @@ class SeedRankControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement()
+    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000])->toArray();
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
@@ -197,23 +197,23 @@ class SeedRankControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
                 [
-                    'id' => $three->id,
-                    'rank' => $three->rank,
-                    'salary' => $three->salary,
+                    'id' => $three['id'],
+                    'rank' => $three['rank'],
+                    'salary' => $three['salary'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_salary_column()
+    public function it_can_filter_seed_ranks_via_the_salary_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -229,21 +229,21 @@ class SeedRankControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement()
+    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
-        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
+        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500])->toArray();
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
-        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000]);
+        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000])->toArray();
 
         $service = $this->app->make(SeedRankService::class);
         $transformer = new SeedRankTransformer();
@@ -257,19 +257,19 @@ class SeedRankControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'rank' => $one->rank,
-                    'salary' => $one->salary,
+                    'id' => $one['id'],
+                    'rank' => $one['rank'],
+                    'salary' => $one['salary'],
                 ],
                 [
-                    'id' => $two->id,
-                    'rank' => $two->rank,
-                    'salary' => $two->salary,
+                    'id' => $two['id'],
+                    'rank' => $two['rank'],
+                    'salary' => $two['salary'],
                 ],
                 [
-                    'id' => $four->id,
-                    'rank' => $four->rank,
-                    'salary' => $four->salary,
+                    'id' => $four['id'],
+                    'rank' => $four['rank'],
+                    'salary' => $four['salary'],
                 ],
             ],
         ], $response->getData(true));

--- a/tests/Unit/Controllers/V0/SeedTestControllerTest.php
+++ b/tests/Unit/Controllers/V0/SeedTestControllerTest.php
@@ -18,9 +18,9 @@ class SeedTestControllerTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_seed_tests()
+    public function it_will_return_a_list_of_seed_tests(): void
     {
-        $seedTests = SeedTest::factory()->count(10)->create();
+        SeedTest::factory()->count(10)->create();
 
         $service = $this->app->make(SeedTestService::class);
         $transformer = new SeedTestTransformer();
@@ -37,51 +37,51 @@ class SeedTestControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_test_using_the_id_key()
+    public function it_will_return_an_individual_seed_test_using_the_id_key(): void
     {
-        $seedTest = SeedTest::factory()->create();
+        $seedTest = SeedTest::factory()->create()->toArray();
 
         $service = $this->app->make(SeedTestService::class);
         $transformer = new SeedTestTransformer();
         $controller = new SeedTestController($service, $transformer);
 
-        $response = $controller->show(new Request(), $seedTest->id);
+        $response = $controller->show(new Request(), $seedTest['id']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedTest->id,
-                'level' => $seedTest->level,
+                'id' => $seedTest['id'],
+                'level' => $seedTest['level'],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_test_using_the_level_key()
+    public function it_will_return_an_individual_seed_test_using_the_level_key(): void
     {
-        $seedTest = SeedTest::factory()->create();
+        $seedTest = SeedTest::factory()->create()->toArray();
 
         $service = $this->app->make(SeedTestService::class);
         $transformer = new SeedTestTransformer();
         $controller = new SeedTestController($service, $transformer);
 
-        $response = $controller->show(new Request(), $seedTest->level);
+        $response = $controller->show(new Request(), $seedTest['level']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedTest->id,
-                'level' => $seedTest->level,
+                'id' => $seedTest['id'],
+                'level' => $seedTest['level'],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -93,11 +93,11 @@ class SeedTestControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_seed_tests_via_the_level_column()
+    public function it_can_search_for_seed_tests_via_the_level_column(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        $three = SeedTest::factory()->create(['level' => 10])->toArray();
 
         $service = $this->app->make(SeedTestService::class);
         $transformer = new SeedTestTransformer();
@@ -111,23 +111,23 @@ class SeedTestControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'level' => $one->level,
+                    'id' => $one['id'],
+                    'level' => $one['level'],
                 ],
                 [
-                    'id' => $three->id,
-                    'level' => $three->level,
+                    'id' => $three['id'],
+                    'level' => $three['level'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_seed_tests_via_the_level_column()
+    public function it_can_filter_seed_tests_via_the_level_column(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        SeedTest::factory()->create(['level' => 10])->toArray();
 
         $service = $this->app->make(SeedTestService::class);
         $transformer = new SeedTestTransformer();
@@ -141,19 +141,19 @@ class SeedTestControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'level' => $one->level,
+                    'id' => $one['id'],
+                    'level' => $one['level'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement()
+    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        $three = SeedTest::factory()->create(['level' => 10])->toArray();
 
         $service = $this->app->make(SeedTestService::class);
         $transformer = new SeedTestTransformer();
@@ -167,21 +167,21 @@ class SeedTestControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'level' => $one->level,
+                    'id' => $one['id'],
+                    'level' => $one['level'],
                 ],
                 [
-                    'id' => $three->id,
-                    'level' => $three->level,
+                    'id' => $three['id'],
+                    'level' => $three['level'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_load_the_test_questions_relation_on_a_list_of_seed_tests()
+    public function it_can_load_the_test_questions_relation_on_a_list_of_seed_tests(): void
     {
-        $seedTests = SeedTest::factory()
+        SeedTest::factory()
             ->count(10)
             ->has(TestQuestion::factory()->count(10))
             ->create();
@@ -208,27 +208,29 @@ class SeedTestControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_the_test_questions_relation_on_an_individual_seed_test()
+    public function it_can_load_the_test_questions_relation_on_an_individual_seed_test(): void
     {
         $seedTest = SeedTest::factory()
             ->has(TestQuestion::factory()->count(1))
-            ->create();
+            ->create()
+            ->load('testQuestions')
+            ->toArray();
 
         $service = $this->app->make(SeedTestService::class);
         $testQuestionTransformer = $this->app->make(TestQuestionTransformer::class);
         $seedTestTransformer = $this->app->make(SeedTestTransformer::class);
         $controller = new SeedTestController($service, $seedTestTransformer);
 
-        $response = $controller->show(new Request(['include' => 'test-questions']), $seedTest->id);
+        $response = $controller->show(new Request(['include' => 'test-questions']), $seedTest['id']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $seedTest->id,
-                'level' => $seedTest->level,
-                'test_questions' => $testQuestionTransformer->transformCollection($seedTest->testQuestions->toArray()),
+                'id' => $seedTest['id'],
+                'level' => $seedTest['level'],
+                'test_questions' => $testQuestionTransformer->transformCollection($seedTest['test_questions']),
             ],
         ], $response->getData(true));
     }

--- a/tests/Unit/Controllers/V0/TestQuestionControllerTest.php
+++ b/tests/Unit/Controllers/V0/TestQuestionControllerTest.php
@@ -18,9 +18,9 @@ class TestQuestionControllerTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_test_questions()
+    public function it_will_return_a_list_of_test_questions(): void
     {
-        $testQuestions = TestQuestion::factory()->count(10)->create();
+        TestQuestion::factory()->count(10)->create();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -37,33 +37,33 @@ class TestQuestionControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_will_return_an_individual_test_question_using_the_id_key()
+    public function it_will_return_an_individual_test_question_using_the_id_key(): void
     {
-        $testQuestion = TestQuestion::factory()->create();
+        $testQuestion = TestQuestion::factory()->create()->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
         $controller = new TestQuestionController($service, $transformer);
 
-        $response = $controller->show(new Request(), $testQuestion->id);
+        $response = $controller->show(new Request(), $testQuestion['id']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $testQuestion->id,
-                'sort_id' => $testQuestion->sort_id,
-                'seed_test_id' => $testQuestion->seed_test_id,
-                'question_number' => $testQuestion->question_number,
-                'question' => $testQuestion->question,
-                'answer' => $testQuestion->answer,
+                'id' => $testQuestion['id'],
+                'sort_id' => $testQuestion['sort_id'],
+                'seed_test_id' => $testQuestion['seed_test_id'],
+                'question_number' => $testQuestion['question_number'],
+                'question' => $testQuestion['question'],
+                'answer' => $testQuestion['answer'],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -75,14 +75,14 @@ class TestQuestionControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_question_number_column()
+    public function it_can_search_for_test_questions_via_the_question_number_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -93,7 +93,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -107,34 +107,34 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_question_column()
+    public function it_can_search_for_test_questions_via_the_question_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -146,7 +146,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -160,34 +160,34 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_answer_column()
+    public function it_can_search_for_test_questions_via_the_answer_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -199,7 +199,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -213,34 +213,34 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_number_column()
+    public function it_can_filter_test_questions_via_the_question_number_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -266,26 +266,26 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -297,7 +297,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -311,34 +311,34 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_column()
+    public function it_can_filter_test_questions_via_the_question_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -364,26 +364,26 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -395,7 +395,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -409,27 +409,27 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_answer_column()
+    public function it_can_filter_test_questions_via_the_answer_column(): void
     {
         TestQuestion::factory()->create([
             'sort_id' => 1,
@@ -442,7 +442,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 5,
             'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
             'answer' => true,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 3,
             'question_number' => 10,
@@ -462,26 +462,26 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $two->id,
-                    'sort_id' => $two->sort_id,
-                    'seed_test_id' => $two->seed_test_id,
-                    'question_number' => $two->question_number,
-                    'question' => $two->question,
-                    'answer' => $two->answer,
+                    'id' => $two['id'],
+                    'sort_id' => $two['sort_id'],
+                    'seed_test_id' => $two['seed_test_id'],
+                    'question_number' => $two['question_number'],
+                    'question' => $two['question'],
+                    'answer' => $two['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -493,7 +493,7 @@ class TestQuestionControllerTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $transformer = $this->app->make(TestQuestionTransformer::class);
@@ -507,29 +507,29 @@ class TestQuestionControllerTest extends TestCase
             'status_code' => 200,
             'data' => [
                 [
-                    'id' => $one->id,
-                    'sort_id' => $one->sort_id,
-                    'seed_test_id' => $one->seed_test_id,
-                    'question_number' => $one->question_number,
-                    'question' => $one->question,
-                    'answer' => $one->answer,
+                    'id' => $one['id'],
+                    'sort_id' => $one['sort_id'],
+                    'seed_test_id' => $one['seed_test_id'],
+                    'question_number' => $one['question_number'],
+                    'question' => $one['question'],
+                    'answer' => $one['answer'],
                 ],
                 [
-                    'id' => $three->id,
-                    'sort_id' => $three->sort_id,
-                    'seed_test_id' => $three->seed_test_id,
-                    'question_number' => $three->question_number,
-                    'question' => $three->question,
-                    'answer' => $three->answer,
+                    'id' => $three['id'],
+                    'sort_id' => $three['sort_id'],
+                    'seed_test_id' => $three['seed_test_id'],
+                    'question_number' => $three['question_number'],
+                    'question' => $three['question'],
+                    'answer' => $three['answer'],
                 ],
             ],
         ], $response->getData(true));
     }
 
     /** @test */
-    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions()
+    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions(): void
     {
-        $testQuestions = TestQuestion::factory()
+        TestQuestion::factory()
             ->count(10)
             ->for(SeedTest::factory())
             ->create();
@@ -556,31 +556,33 @@ class TestQuestionControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_the_seed_test_relation_on_an_individual_test_question()
+    public function it_can_load_the_seed_test_relation_on_an_individual_test_question(): void
     {
         $testQuestion = TestQuestion::factory()
             ->for(SeedTest::factory())
-            ->create();
+            ->create()
+            ->load('seedTest')
+            ->toArray();
 
         $service = $this->app->make(TestQuestionService::class);
         $seedTestTransformer = $this->app->make(SeedTestTransformer::class);
         $testQuestionTransformer = $this->app->make(TestQuestionTransformer::class);
         $controller = new TestQuestionController($service, $testQuestionTransformer);
 
-        $response = $controller->show(new Request(['include' => 'seed-test']), $testQuestion->id);
+        $response = $controller->show(new Request(['include' => 'seed-test']), $testQuestion['id']);
 
         $this->assertEquals([
             'success' => true,
             'message' => 'Successfully retrieved data.',
             'status_code' => 200,
             'data' => [
-                'id' => $testQuestion->id,
-                'sort_id' => $testQuestion->sort_id,
-                'seed_test_id' => $testQuestion->seed_test_id,
-                'question_number' => $testQuestion->question_number,
-                'question' => $testQuestion->question,
-                'answer' => $testQuestion->answer,
-                'seed_test' => $seedTestTransformer->transformRecord($testQuestion->seedTest->toArray()),
+                'id' => $testQuestion['id'],
+                'sort_id' => $testQuestion['sort_id'],
+                'seed_test_id' => $testQuestion['seed_test_id'],
+                'question_number' => $testQuestion['question_number'],
+                'question' => $testQuestion['question'],
+                'answer' => $testQuestion['answer'],
+                'seed_test' => $seedTestTransformer->transformRecord($testQuestion['seed_test']),
             ],
         ], $response->getData(true));
     }

--- a/tests/Unit/Middleware/CaptureInboundRequestTest.php
+++ b/tests/Unit/Middleware/CaptureInboundRequestTest.php
@@ -13,7 +13,7 @@ class CaptureInboundRequestTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_capture_successful_requests()
+    public function it_will_capture_successful_requests(): void
     {
         $request = new Request();
         $response = new JsonResponse([], 200);
@@ -41,7 +41,7 @@ class CaptureInboundRequestTest extends TestCase
     }
 
     /** @test */
-    public function it_will_capture_unsuccessful_requests()
+    public function it_will_capture_unsuccessful_requests(): void
     {
         $request = new Request();
         $response = new JsonResponse([], 500);

--- a/tests/Unit/Models/ElementTest.php
+++ b/tests/Unit/Models/ElementTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase as TestCase;
 class ElementTest extends TestCase
 {
     /** @test */
-    public function it_uses_the_proper_database_table()
+    public function it_uses_the_proper_database_table(): void
     {
         $element = new Element();
 
@@ -16,7 +16,7 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
     {
         $element = new Element();
 
@@ -24,7 +24,7 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
     {
         $element = new Element();
 
@@ -38,7 +38,7 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_cast_type_for_each_field()
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
     {
         $element = new Element();
         $fields = $element->getCasts();
@@ -53,7 +53,7 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_searchable()
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
     {
         $element = new Element();
 
@@ -65,7 +65,7 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_filterable()
+    public function it_explicitly_defines_the_fields_that_are_filterable(): void
     {
         $element = new Element();
 
@@ -77,7 +77,7 @@ class ElementTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_route_key_name()
+    public function it_explicitly_defines_the_route_key_name(): void
     {
         $element = new Element();
 

--- a/tests/Unit/Models/ModelTest.php
+++ b/tests/Unit/Models/ModelTest.php
@@ -17,7 +17,7 @@ class ModelTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_explicitly_disables_incrementing_primary_keys()
+    public function it_explicitly_disables_incrementing_primary_keys(): void
     {
         $model = new Model();
 
@@ -25,7 +25,7 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_the_primary_key_column_explicitly()
+    public function it_sets_the_primary_key_column_explicitly(): void
     {
         $model = new Model();
 
@@ -33,7 +33,7 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_the_primary_key_type_to_string()
+    public function it_sets_the_primary_key_type_to_string(): void
     {
         $model = new Model();
 
@@ -41,7 +41,7 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_order_results_should_be_returned_by()
+    public function it_explicitly_defines_the_order_results_should_be_returned_by(): void
     {
         $model = new Model();
 
@@ -49,7 +49,7 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_allow_properties_to_be_assigned_in_mass()
+    public function it_does_not_allow_properties_to_be_assigned_in_mass(): void
     {
         $model = new Model();
 
@@ -57,7 +57,7 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_hidden_fields_for_api_consumption()
+    public function it_explicitly_defines_the_hidden_fields_for_api_consumption(): void
     {
         $model = new Model();
 
@@ -71,16 +71,16 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_uses_uuids_for_the_primary_key()
+    public function it_uses_uuids_for_the_primary_key(): void
     {
         $this->assertTrue(in_array(
             Uuids::class,
-            class_uses(Model::class)
+            class_uses(Model::class) ?: []
         ));
     }
 
     /** @test */
-    public function it_will_not_allow_the_uuid_to_be_changed()
+    public function it_will_not_allow_the_uuid_to_be_changed(): void
     {
         $seedRank = SeedRank::factory()->create();
 
@@ -91,38 +91,38 @@ class ModelTest extends TestCase
     }
 
     /** @test */
-    public function it_can_order_query_results()
+    public function it_can_order_query_results(): void
     {
         $this->assertTrue(in_array(
             OrdersQueryResults::class,
-            class_uses(Model::class)
+            class_uses(Model::class) ?: []
         ));
     }
 
     /** @test */
-    public function it_includes_search_functionality()
+    public function it_includes_search_functionality(): void
     {
         $this->assertTrue(in_array(
             Searchable::class,
-            class_uses(Model::class)
+            class_uses(Model::class) ?: []
         ));
     }
 
     /** @test */
-    public function it_includes_the_ability_to_filter_records_by_fields()
+    public function it_includes_the_ability_to_filter_records_by_fields(): void
     {
         $this->assertTrue(in_array(
             FiltersRecordsByFields::class,
-            class_uses(Model::class)
+            class_uses(Model::class) ?: []
         ));
     }
 
     /** @test */
-    public function it_loads_relations_through_services()
+    public function it_loads_relations_through_services(): void
     {
         $this->assertTrue(in_array(
             LoadsRelationsThroughServices::class,
-            class_uses(Model::class)
+            class_uses(Model::class) ?: []
         ));
     }
 }

--- a/tests/Unit/Models/SeedRankTest.php
+++ b/tests/Unit/Models/SeedRankTest.php
@@ -11,7 +11,7 @@ class SeedRankTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_uses_the_proper_database_table()
+    public function it_uses_the_proper_database_table(): void
     {
         $seedRank = new SeedRank();
 
@@ -19,7 +19,7 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
     {
         $seedRank = new SeedRank();
 
@@ -27,7 +27,7 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
     {
         $seedRank = new SeedRank();
 
@@ -41,7 +41,7 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_cast_type_for_each_field()
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
     {
         $seedRank = new SeedRank();
         $fields = $seedRank->getCasts();
@@ -56,7 +56,7 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_searchable()
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
     {
         $seedRank = new SeedRank();
 
@@ -69,7 +69,7 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_filterable()
+    public function it_explicitly_defines_the_fields_that_are_filterable(): void
     {
         $seedRank = new SeedRank();
 
@@ -82,7 +82,7 @@ class SeedRankTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_route_key_name()
+    public function it_explicitly_defines_the_route_key_name(): void
     {
         $seedRank = new SeedRank();
 

--- a/tests/Unit/Models/SeedTestTest.php
+++ b/tests/Unit/Models/SeedTestTest.php
@@ -11,7 +11,7 @@ class SeedTestTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_uses_the_proper_database_table()
+    public function it_uses_the_proper_database_table(): void
     {
         $seedTest = new SeedTest();
 
@@ -19,7 +19,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
     {
         $seedTest = new SeedTest();
 
@@ -27,7 +27,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
     {
         $seedTest = new SeedTest();
 
@@ -41,7 +41,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_cast_type_for_each_field()
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
     {
         $seedTest = new SeedTest();
         $fields = $seedTest->getCasts();
@@ -55,7 +55,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_searchable()
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
     {
         $seedTest = new SeedTest();
 
@@ -67,7 +67,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_filterable()
+    public function it_explicitly_defines_the_fields_that_are_filterable(): void
     {
         $seedTest = new SeedTest();
 
@@ -79,7 +79,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource()
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource(): void
     {
         $seedTest = new SeedTest();
 
@@ -91,7 +91,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource()
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource(): void
     {
         $seedTest = new SeedTest();
 
@@ -101,7 +101,7 @@ class SeedTestTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_route_key_name()
+    public function it_explicitly_defines_the_route_key_name(): void
     {
         $seedTest = new SeedTest();
 

--- a/tests/Unit/Models/StatTest.php
+++ b/tests/Unit/Models/StatTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase as TestCase;
 class StatTest extends TestCase
 {
     /** @test */
-    public function it_uses_the_proper_database_table()
+    public function it_uses_the_proper_database_table(): void
     {
         $stat = new Stat();
 
@@ -16,7 +16,7 @@ class StatTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
     {
         $stat = new Stat();
 
@@ -24,7 +24,7 @@ class StatTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
     {
         $stat = new Stat();
 
@@ -39,7 +39,7 @@ class StatTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_cast_type_for_each_field()
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
     {
         $stat = new Stat();
         $fields = $stat->getCasts();
@@ -55,7 +55,7 @@ class StatTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_searchable()
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
     {
         $stat = new Stat();
 
@@ -65,7 +65,7 @@ class StatTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_filterable()
+    public function it_explicitly_defines_the_fields_that_are_filterable(): void
     {
         $stat = new Stat();
 

--- a/tests/Unit/Models/StatusEffectTest.php
+++ b/tests/Unit/Models/StatusEffectTest.php
@@ -11,7 +11,7 @@ class StatusEffectTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_uses_the_proper_database_table()
+    public function it_uses_the_proper_database_table(): void
     {
         $statusEffect = new StatusEffect();
 
@@ -19,7 +19,7 @@ class StatusEffectTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
     {
         $statusEffect = new StatusEffect();
 
@@ -27,7 +27,7 @@ class StatusEffectTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
     {
         $statusEffect = new StatusEffect();
 
@@ -43,7 +43,7 @@ class StatusEffectTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_cast_type_for_each_field()
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
     {
         $statusEffect = new StatusEffect();
         $fields = $statusEffect->getCasts();
@@ -60,7 +60,7 @@ class StatusEffectTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_searchable()
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
     {
         $statusEffect = new StatusEffect();
 
@@ -74,7 +74,7 @@ class StatusEffectTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_filterable()
+    public function it_explicitly_defines_the_fields_that_are_filterable(): void
     {
         $statusEffect = new StatusEffect();
 
@@ -88,7 +88,7 @@ class StatusEffectTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_route_key_name()
+    public function it_explicitly_defines_the_route_key_name(): void
     {
         $statusEffect = new StatusEffect();
 

--- a/tests/Unit/Models/TestQuestionTest.php
+++ b/tests/Unit/Models/TestQuestionTest.php
@@ -11,7 +11,7 @@ class TestQuestionTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_uses_the_proper_database_table()
+    public function it_uses_the_proper_database_table(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -19,7 +19,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering()
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -27,7 +27,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_visible_fields_for_api_consumption()
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -45,7 +45,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_cast_type_for_each_field()
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
     {
         $testQuestion = new TestQuestion();
         $fields = $testQuestion->getCasts();
@@ -63,7 +63,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_searchable()
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -77,7 +77,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_fields_that_are_filterable()
+    public function it_explicitly_defines_the_fields_that_are_filterable(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -91,7 +91,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource()
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -103,7 +103,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource()
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource(): void
     {
         $testQuestion = new TestQuestion();
 
@@ -113,7 +113,7 @@ class TestQuestionTest extends TestCase
     }
 
     /** @test */
-    public function it_explicitly_defines_the_route_key_name()
+    public function it_explicitly_defines_the_route_key_name(): void
     {
         $testQuestion = new TestQuestion();
 

--- a/tests/Unit/Services/SeedRankServiceTest.php
+++ b/tests/Unit/Services/SeedRankServiceTest.php
@@ -14,7 +14,7 @@ class SeedRankServiceTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_seed_ranks()
+    public function it_will_return_a_list_of_seed_ranks(): void
     {
         $seedRanks = SeedRank::factory()->count(10)->create();
 
@@ -23,41 +23,37 @@ class SeedRankServiceTest extends TestCase
 
         $records = $service->all(new Request());
 
-        $sortedSeedRanks = $seedRanks->sortBy([
-            [$model->getOrderByField(), $model->getOrderByDirection()],
-        ]);
-
-        $this->assertEquals($sortedSeedRanks->toArray(), $records);
+        $this->assertCount(10, $records);
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_rank_using_the_id_key()
+    public function it_will_return_an_individual_seed_rank_using_the_id_key(): void
     {
-        $seedRank = SeedRank::factory()->create();
+        $seedRank = SeedRank::factory()->create()->toArray();
 
         $model = new SeedRank();
         $service = new SeedRankService($model);
 
-        $records = $service->findOrFail($seedRank->id, new Request());
+        $records = $service->findOrFail($seedRank['id'], new Request());
 
-        $this->assertEquals($seedRank->toArray(), $records);
+        $this->assertEquals($seedRank, $records);
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_rank_using_the_rank_key()
+    public function it_will_return_an_individual_seed_rank_using_the_rank_key(): void
     {
-        $seedRank = SeedRank::factory()->create();
+        $seedRank = SeedRank::factory()->create()->toArray();
 
         $model = new SeedRank();
         $service = new SeedRankService($model);
 
-        $records = $service->findOrFail($seedRank->rank, new Request());
+        $records = $service->findOrFail($seedRank['rank'], new Request());
 
-        $this->assertEquals($seedRank->toArray(), $records);
+        $this->assertEquals($seedRank, $records);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -68,11 +64,11 @@ class SeedRankServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_seed_ranks_via_the_rank_column()
+    public function it_can_search_for_seed_ranks_via_the_rank_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000])->toArray();
 
         $model = new SeedRank();
         $service = new SeedRankService($model);
@@ -81,22 +77,22 @@ class SeedRankServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'rank' => $one->rank,
-                'salary' => $one->salary,
+                'id' => $one['id'],
+                'rank' => $one['rank'],
+                'salary' => $one['salary'],
             ],
             [
-                'id' => $three->id,
-                'rank' => $three->rank,
-                'salary' => $three->salary,
+                'id' => $three['id'],
+                'rank' => $three['rank'],
+                'salary' => $three['salary'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_search_for_seed_ranks_via_the_salary_column()
+    public function it_can_search_for_seed_ranks_via_the_salary_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -107,17 +103,17 @@ class SeedRankServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'rank' => $one->rank,
-                'salary' => $one->salary,
+                'id' => $one['id'],
+                'rank' => $one['rank'],
+                'salary' => $one['salary'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_rank_column()
+    public function it_can_filter_seed_ranks_via_the_rank_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -128,19 +124,19 @@ class SeedRankServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'rank' => $one->rank,
-                'salary' => $one->salary,
+                'id' => $one['id'],
+                'rank' => $one['rank'],
+                'salary' => $one['salary'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement()
+    public function it_can_filter_seed_ranks_via_the_rank_column_using_the_like_statement(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '5', 'salary' => 3000]);
-        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
+        $three = SeedRank::factory()->create(['rank' => '10', 'salary' => 8000])->toArray();
 
         $model = new SeedRank();
         $service = new SeedRankService($model);
@@ -149,22 +145,22 @@ class SeedRankServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'rank' => $one->rank,
-                'salary' => $one->salary,
+                'id' => $one['id'],
+                'rank' => $one['rank'],
+                'salary' => $one['salary'],
             ],
             [
-                'id' => $three->id,
-                'rank' => $three->rank,
-                'salary' => $three->salary,
+                'id' => $three['id'],
+                'rank' => $three['rank'],
+                'salary' => $three['salary'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_salary_column()
+    public function it_can_filter_seed_ranks_via_the_salary_column(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
         SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
 
@@ -175,20 +171,20 @@ class SeedRankServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'rank' => $one->rank,
-                'salary' => $one->salary,
+                'id' => $one['id'],
+                'rank' => $one['rank'],
+                'salary' => $one['salary'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement()
+    public function it_can_filter_seed_ranks_via_the_salary_column_using_the_like_statement(): void
     {
-        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500]);
-        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500]);
+        $one = SeedRank::factory()->create(['rank' => '1', 'salary' => 500])->toArray();
+        $two = SeedRank::factory()->create(['rank' => '3', 'salary' => 1500])->toArray();
         SeedRank::factory()->create(['rank' => '10', 'salary' => 8000]);
-        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000]);
+        $four = SeedRank::factory()->create(['rank' => '20', 'salary' => 15000])->toArray();
 
         $model = new SeedRank();
         $service = new SeedRankService($model);
@@ -197,19 +193,19 @@ class SeedRankServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'rank' => $one->rank,
-                'salary' => $one->salary,
+                'id' => $one['id'],
+                'rank' => $one['rank'],
+                'salary' => $one['salary'],
             ],
             [
-                'id' => $two->id,
-                'rank' => $two->rank,
-                'salary' => $two->salary,
+                'id' => $two['id'],
+                'rank' => $two['rank'],
+                'salary' => $two['salary'],
             ],
             [
-                'id' => $four->id,
-                'rank' => $four->rank,
-                'salary' => $four->salary,
+                'id' => $four['id'],
+                'rank' => $four['rank'],
+                'salary' => $four['salary'],
             ],
         ], $records);
     }

--- a/tests/Unit/Services/SeedTestServiceTest.php
+++ b/tests/Unit/Services/SeedTestServiceTest.php
@@ -15,7 +15,7 @@ class SeedTestServiceTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_seed_tests()
+    public function it_will_return_a_list_of_seed_tests(): void
     {
         $seedTests = SeedTest::factory()->count(10)->create();
 
@@ -24,47 +24,43 @@ class SeedTestServiceTest extends TestCase
 
         $records = $service->all(new Request());
 
-        $sortedSeedTests = $seedTests->sortBy([
-            [$model->getOrderByField(), $model->getOrderByDirection()],
-        ]);
-
         $this->assertCount(10, $records);
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_test_using_the_id_key()
+    public function it_will_return_an_individual_seed_test_using_the_id_key(): void
     {
-        $seedTest = SeedTest::factory()->create();
+        $seedTest = SeedTest::factory()->create()->toArray();
 
         $model = new SeedTest();
         $service = new SeedTestService($model);
 
-        $records = $service->findOrFail($seedTest->id, new Request());
+        $records = $service->findOrFail($seedTest['id'], new Request());
 
         $this->assertEquals([
-            'id' => $seedTest->id,
-            'level' => $seedTest->level,
+            'id' => $seedTest['id'],
+            'level' => $seedTest['level'],
         ], $records);
     }
 
     /** @test */
-    public function it_will_return_an_individual_seed_test_using_the_level_key()
+    public function it_will_return_an_individual_seed_test_using_the_level_key(): void
     {
-        $seedTest = SeedTest::factory()->create();
+        $seedTest = SeedTest::factory()->create()->toArray();
 
         $model = new SeedTest();
         $service = new SeedTestService($model);
 
-        $records = $service->findOrFail($seedTest->level, new Request());
+        $records = $service->findOrFail($seedTest['level'], new Request());
 
         $this->assertEquals([
-            'id' => $seedTest->id,
-            'level' => $seedTest->level,
+            'id' => $seedTest['id'],
+            'level' => $seedTest['level'],
         ], $records);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -75,11 +71,11 @@ class SeedTestServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_seed_tests_via_the_level_column()
+    public function it_can_search_for_seed_tests_via_the_level_column(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        $three = SeedTest::factory()->create(['level' => 10])->toArray();
 
         $model = new SeedTest();
         $service = new SeedTestService($model);
@@ -88,20 +84,20 @@ class SeedTestServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'level' => $one->level,
+                'id' => $one['id'],
+                'level' => $one['level'],
             ],
             [
-                'id' => $three->id,
-                'level' => $three->level,
+                'id' => $three['id'],
+                'level' => $three['level'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_seed_tests_via_the_level_column()
+    public function it_can_filter_seed_tests_via_the_level_column(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
         SeedTest::factory()->create(['level' => 10]);
 
@@ -112,18 +108,18 @@ class SeedTestServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'level' => $one->level,
+                'id' => $one['id'],
+                'level' => $one['level'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement()
+    public function it_can_filter_seed_tests_via_the_level_column_using_the_like_statement(): void
     {
-        $one = SeedTest::factory()->create(['level' => 1]);
+        $one = SeedTest::factory()->create(['level' => 1])->toArray();
         SeedTest::factory()->create(['level' => 5]);
-        $three = SeedTest::factory()->create(['level' => 10]);
+        $three = SeedTest::factory()->create(['level' => 10])->toArray();
 
         $model = new SeedTest();
         $service = new SeedTestService($model);
@@ -132,20 +128,20 @@ class SeedTestServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'level' => $one->level,
+                'id' => $one['id'],
+                'level' => $one['level'],
             ],
             [
-                'id' => $three->id,
-                'level' => $three->level,
+                'id' => $three['id'],
+                'level' => $three['level'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_load_the_test_questions_relation_on_a_list_of_seed_tests()
+    public function it_can_load_the_test_questions_relation_on_a_list_of_seed_tests(): void
     {
-        $seedTests = SeedTest::factory()
+        SeedTest::factory()
             ->count(10)
             ->has(TestQuestion::factory()->count(10))
             ->create();
@@ -155,10 +151,6 @@ class SeedTestServiceTest extends TestCase
 
         $records = $service->all(new Request(['include' => 'test-questions']));
 
-        $sortedSeedTests = $seedTests->sortBy([
-            [$model->getOrderByField(), $model->getOrderByDirection()],
-        ]);
-
         $this->assertArraySubset([
             [
                 'test_questions' => [],
@@ -167,21 +159,23 @@ class SeedTestServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_the_test_questions_relation_on_an_individual_seed_test()
+    public function it_can_load_the_test_questions_relation_on_an_individual_seed_test(): void
     {
         $seedTest = SeedTest::factory()
             ->has(TestQuestion::factory()->count(1))
-            ->create();
+            ->create()
+            ->load('testQuestions')
+            ->toArray();
 
         $model = new SeedTest();
         $service = new SeedTestService($model);
 
-        $records = $service->findOrFail($seedTest->id, new Request(['include' => 'test-questions']));
+        $records = $service->findOrFail($seedTest['id'], new Request(['include' => 'test-questions']));
 
         $this->assertEquals([
-            'id' => $seedTest->id,
-            'level' => $seedTest->level,
-            'test_questions' => $seedTest->testQuestions->toArray(),
+            'id' => $seedTest['id'],
+            'level' => $seedTest['level'],
+            'test_questions' => $seedTest['test_questions'],
         ], $records);
     }
 }

--- a/tests/Unit/Services/TestQuestionServiceTest.php
+++ b/tests/Unit/Services/TestQuestionServiceTest.php
@@ -15,44 +15,40 @@ class TestQuestionServiceTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_will_return_a_list_of_test_questions()
+    public function it_will_return_a_list_of_test_questions(): void
     {
-        $testQuestions = TestQuestion::factory()->count(10)->create();
+        TestQuestion::factory()->count(10)->create();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
 
         $records = $service->all(new Request());
 
-        $sortedTestQuestions = $testQuestions->sortBy([
-            [$model->getOrderByField(), $model->getOrderByDirection()],
-        ]);
-
         $this->assertCount(10, $records);
     }
 
     /** @test */
-    public function it_will_return_an_individual_test_question_using_the_id_key()
+    public function it_will_return_an_individual_test_question_using_the_id_key(): void
     {
-        $testQuestion = TestQuestion::factory()->create();
+        $testQuestion = TestQuestion::factory()->create()->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
 
-        $records = $service->findOrFail($testQuestion->id, new Request());
+        $records = $service->findOrFail($testQuestion['id'], new Request());
 
         $this->assertEquals([
-            'id' => $testQuestion->id,
-            'sort_id' => $testQuestion->sort_id,
-            'seed_test_id' => $testQuestion->seed_test_id,
-            'question_number' => $testQuestion->question_number,
-            'question' => $testQuestion->question,
-            'answer' => $testQuestion->answer,
+            'id' => $testQuestion['id'],
+            'sort_id' => $testQuestion['sort_id'],
+            'seed_test_id' => $testQuestion['seed_test_id'],
+            'question_number' => $testQuestion['question_number'],
+            'question' => $testQuestion['question'],
+            'answer' => $testQuestion['answer'],
         ], $records);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_an_individual_record_is_not_found()
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
     {
         $this->expectException(NotFoundHttpException::class);
 
@@ -63,14 +59,14 @@ class TestQuestionServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_question_number_column()
+    public function it_can_search_for_test_questions_via_the_question_number_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -82,7 +78,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -91,33 +87,33 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
             [
-                'id' => $three->id,
-                'sort_id' => $three->sort_id,
-                'seed_test_id' => $three->seed_test_id,
-                'question_number' => $three->question_number,
-                'question' => $three->question,
-                'answer' => $three->answer,
+                'id' => $three['id'],
+                'sort_id' => $three['sort_id'],
+                'seed_test_id' => $three['seed_test_id'],
+                'question_number' => $three['question_number'],
+                'question' => $three['question'],
+                'answer' => $three['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_question_column()
+    public function it_can_search_for_test_questions_via_the_question_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -129,7 +125,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -138,33 +134,33 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
             [
-                'id' => $three->id,
-                'sort_id' => $three->sort_id,
-                'seed_test_id' => $three->seed_test_id,
-                'question_number' => $three->question_number,
-                'question' => $three->question,
-                'answer' => $three->answer,
+                'id' => $three['id'],
+                'sort_id' => $three['sort_id'],
+                'seed_test_id' => $three['seed_test_id'],
+                'question_number' => $three['question_number'],
+                'question' => $three['question'],
+                'answer' => $three['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_search_for_test_questions_via_the_answer_column()
+    public function it_can_search_for_test_questions_via_the_answer_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -176,7 +172,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -185,40 +181,40 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
             [
-                'id' => $three->id,
-                'sort_id' => $three->sort_id,
-                'seed_test_id' => $three->seed_test_id,
-                'question_number' => $three->question_number,
-                'question' => $three->question,
-                'answer' => $three->answer,
+                'id' => $three['id'],
+                'sort_id' => $three['sort_id'],
+                'seed_test_id' => $three['seed_test_id'],
+                'question_number' => $three['question_number'],
+                'question' => $three['question'],
+                'answer' => $three['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_number_column()
+    public function it_can_filter_test_questions_via_the_question_number_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
             'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
             'answer' => true,
         ]);
-        $three = TestQuestion::factory()->create([
+        TestQuestion::factory()->create([
             'sort_id' => 3,
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
@@ -232,25 +228,25 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_question_number_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -262,7 +258,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -271,45 +267,45 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
             [
-                'id' => $three->id,
-                'sort_id' => $three->sort_id,
-                'seed_test_id' => $three->seed_test_id,
-                'question_number' => $three->question_number,
-                'question' => $three->question,
-                'answer' => $three->answer,
+                'id' => $three['id'],
+                'sort_id' => $three['sort_id'],
+                'seed_test_id' => $three['seed_test_id'],
+                'question_number' => $three['question_number'],
+                'question' => $three['question'],
+                'answer' => $three['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_column()
+    public function it_can_filter_test_questions_via_the_question_column(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
             'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
             'answer' => true,
         ]);
-        $three = TestQuestion::factory()->create([
+        TestQuestion::factory()->create([
             'sort_id' => 3,
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -318,25 +314,25 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_question_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -348,7 +344,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -357,26 +353,26 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
             [
-                'id' => $three->id,
-                'sort_id' => $three->sort_id,
-                'seed_test_id' => $three->seed_test_id,
-                'question_number' => $three->question_number,
-                'question' => $three->question,
-                'answer' => $three->answer,
+                'id' => $three['id'],
+                'sort_id' => $three['sort_id'],
+                'seed_test_id' => $three['seed_test_id'],
+                'question_number' => $three['question_number'],
+                'question' => $three['question'],
+                'answer' => $three['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_answer_column()
+    public function it_can_filter_test_questions_via_the_answer_column(): void
     {
         TestQuestion::factory()->create([
             'sort_id' => 1,
@@ -389,7 +385,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 5,
             'question' => 'Whoever strikes the finishing blow in battle receives the most EXP.',
             'answer' => true,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 3,
             'question_number' => 10,
@@ -404,25 +400,25 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $two->id,
-                'sort_id' => $two->sort_id,
-                'seed_test_id' => $two->seed_test_id,
-                'question_number' => $two->question_number,
-                'question' => $two->question,
-                'answer' => $two->answer,
+                'id' => $two['id'],
+                'sort_id' => $two['sort_id'],
+                'seed_test_id' => $two['seed_test_id'],
+                'question_number' => $two['question_number'],
+                'question' => $two['question'],
+                'answer' => $two['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement()
+    public function it_can_filter_test_questions_via_the_answer_column_using_the_like_statement(): void
     {
         $one = TestQuestion::factory()->create([
             'sort_id' => 1,
             'question_number' => 1,
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
-        ]);
+        ])->toArray();
         TestQuestion::factory()->create([
             'sort_id' => 2,
             'question_number' => 5,
@@ -434,7 +430,7 @@ class TestQuestionServiceTest extends TestCase
             'question_number' => 10,
             'question' => 'You can stock up to 255 of each magic.',
             'answer' => false,
-        ]);
+        ])->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
@@ -443,28 +439,28 @@ class TestQuestionServiceTest extends TestCase
 
         $this->assertEquals([
             [
-                'id' => $one->id,
-                'sort_id' => $one->sort_id,
-                'seed_test_id' => $one->seed_test_id,
-                'question_number' => $one->question_number,
-                'question' => $one->question,
-                'answer' => $one->answer,
+                'id' => $one['id'],
+                'sort_id' => $one['sort_id'],
+                'seed_test_id' => $one['seed_test_id'],
+                'question_number' => $one['question_number'],
+                'question' => $one['question'],
+                'answer' => $one['answer'],
             ],
             [
-                'id' => $three->id,
-                'sort_id' => $three->sort_id,
-                'seed_test_id' => $three->seed_test_id,
-                'question_number' => $three->question_number,
-                'question' => $three->question,
-                'answer' => $three->answer,
+                'id' => $three['id'],
+                'sort_id' => $three['sort_id'],
+                'seed_test_id' => $three['seed_test_id'],
+                'question_number' => $three['question_number'],
+                'question' => $three['question'],
+                'answer' => $three['answer'],
             ],
         ], $records);
     }
 
     /** @test */
-    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions()
+    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions(): void
     {
-        $testQuestions = TestQuestion::factory()
+        TestQuestion::factory()
             ->count(10)
             ->for(SeedTest::factory())
             ->create();
@@ -474,10 +470,6 @@ class TestQuestionServiceTest extends TestCase
 
         $records = $service->all(new Request(['include' => 'seed-test']));
 
-        $sortedTestQuestions = $testQuestions->sortBy([
-            [$model->getOrderByField(), $model->getOrderByDirection()],
-        ]);
-
         $this->assertArraySubset([
             [
                 'seed_test' => [],
@@ -486,25 +478,27 @@ class TestQuestionServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_load_the_seed_test_relation_on_an_individual_test_question()
+    public function it_can_load_the_seed_test_relation_on_an_individual_test_question(): void
     {
         $testQuestion = TestQuestion::factory()
             ->for(SeedTest::factory())
-            ->create();
+            ->create()
+            ->load('seedTest')
+            ->toArray();
 
         $model = new TestQuestion();
         $service = new TestQuestionService($model);
 
-        $records = $service->findOrFail($testQuestion->id, new Request(['include' => 'seed-test']));
+        $records = $service->findOrFail($testQuestion['id'], new Request(['include' => 'seed-test']));
 
         $this->assertEquals([
-            'id' => $testQuestion->id,
-            'sort_id' => $testQuestion->sort_id,
-            'seed_test_id' => $testQuestion->seed_test_id,
-            'question_number' => $testQuestion->question_number,
-            'question' => $testQuestion->question,
-            'answer' => $testQuestion->answer,
-            'seed_test' => $testQuestion->seedTest->toArray(),
+            'id' => $testQuestion['id'],
+            'sort_id' => $testQuestion['sort_id'],
+            'seed_test_id' => $testQuestion['seed_test_id'],
+            'question_number' => $testQuestion['question_number'],
+            'question' => $testQuestion['question'],
+            'answer' => $testQuestion['answer'],
+            'seed_test' => $testQuestion['seed_test'],
         ], $records);
     }
 }

--- a/tests/Unit/Traits/LoadsRelationsThroughServicesTest.php
+++ b/tests/Unit/Traits/LoadsRelationsThroughServicesTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 class LoadsRelationsThroughServicesTest extends TestCase
 {
     /** @test */
-    public function it_will_recursively_look_through_child_relations_to_validate_includes()
+    public function it_will_recursively_look_through_child_relations_to_validate_includes(): void
     {
         $seedTest = new SeedTest();
 
@@ -19,7 +19,7 @@ class LoadsRelationsThroughServicesTest extends TestCase
     }
 
     /** @test */
-    public function it_will_validate_that_the_relation_exists_before_trying_to_retrieve_the_relation()
+    public function it_will_validate_that_the_relation_exists_before_trying_to_retrieve_the_relation(): void
     {
         $seedTest = new SeedTest();
 
@@ -30,7 +30,7 @@ class LoadsRelationsThroughServicesTest extends TestCase
     }
 
     /** @test */
-    public function it_will_only_load_two_levels_of_relations()
+    public function it_will_only_load_two_levels_of_relations(): void
     {
         $seedTest = new SeedTest();
 

--- a/tests/Unit/Transformers/RecordTransformerTest.php
+++ b/tests/Unit/Transformers/RecordTransformerTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 class RecordTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_return_an_empty_array_when_transforming_a_record_if_not_overridden()
+    public function it_will_return_an_empty_array_when_transforming_a_record_if_not_overridden(): void
     {
         $data = [
             'id' => 'some-random-uuid',

--- a/tests/Unit/Transformers/V0/ElementTransformerTest.php
+++ b/tests/Unit/Transformers/V0/ElementTransformerTest.php
@@ -4,60 +4,59 @@ namespace Tests\Unit\Transformers\V0;
 
 use App\Http\Transformers\V0\ElementTransformer;
 use App\Models\Element;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
 class ElementTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_transform_a_single_record()
+    public function it_will_transform_a_single_record(): void
     {
         $element = Element::factory()->make([
             'id' => 'some-random-uuid',
             'sort_id' => 1,
             'name' => 'fire',
             'arbitrary' => 'data',
-        ]);
+        ])->toArray();
 
         $transformer = new ElementTransformer();
 
-        $transformedRecord = $transformer->transformRecord($element->toArray());
+        $transformedRecord = $transformer->transformRecord($element);
 
         $this->assertEquals([
-            'id' => $element->id,
-            'sort_id' => $element->sort_id,
-            'name' => $element->name,
+            'id' => $element['id'],
+            'sort_id' => $element['sort_id'],
+            'name' => $element['name'],
         ], $transformedRecord);
     }
 
     /** @test */
-    public function it_will_transform_a_collection_of_records()
+    public function it_will_transform_a_collection_of_records(): void
     {
-        $elements = Element::factory()->count(3)->make(new Sequence(
+        $elements = Element::factory()->count(3)->sequence(
             ['id' => 'one', 'sort_id' => 1],
             ['id' => 'two', 'sort_id' => 2],
             ['id' => 'three', 'sort_id' => 3]
-        ));
+        )->make()->toArray();
 
         $transformer = new ElementTransformer();
 
-        $transformedRecords = $transformer->transformCollection($elements->toArray());
+        $transformedRecords = $transformer->transformCollection($elements);
 
         $this->assertEquals([
             [
-                'id' => $elements[0]->id,
-                'sort_id' => $elements[0]->sort_id,
-                'name' => $elements[0]->name,
+                'id' => $elements[0]['id'],
+                'sort_id' => $elements[0]['sort_id'],
+                'name' => $elements[0]['name'],
             ],
             [
-                'id' => $elements[1]->id,
-                'sort_id' => $elements[1]->sort_id,
-                'name' => $elements[1]->name,
+                'id' => $elements[1]['id'],
+                'sort_id' => $elements[1]['sort_id'],
+                'name' => $elements[1]['name'],
             ],
             [
-                'id' => $elements[2]->id,
-                'sort_id' => $elements[2]->sort_id,
-                'name' => $elements[2]->name,
+                'id' => $elements[2]['id'],
+                'sort_id' => $elements[2]['sort_id'],
+                'name' => $elements[2]['name'],
             ],
         ], $transformedRecords);
     }

--- a/tests/Unit/Transformers/V0/SeedRankTransformerTest.php
+++ b/tests/Unit/Transformers/V0/SeedRankTransformerTest.php
@@ -4,60 +4,59 @@ namespace Tests\Unit\Transformers\V0;
 
 use App\Http\Transformers\V0\SeedRankTransformer;
 use App\Models\SeedRank;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
 class SeedRankTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_transform_a_single_record()
+    public function it_will_transform_a_single_record(): void
     {
         $seedRank = SeedRank::factory()->make([
             'id' => 'some-random-uuid',
             'rank' => '5',
             'salary' => 3000,
             'arbitrary' => 'data',
-        ]);
+        ])->toArray();
 
         $transformer = new SeedRankTransformer();
 
-        $transformedRecord = $transformer->transformRecord($seedRank->toArray());
+        $transformedRecord = $transformer->transformRecord($seedRank);
 
         $this->assertEquals([
-            'id' => $seedRank->id,
-            'rank' => $seedRank->rank,
-            'salary' => $seedRank->salary,
+            'id' => $seedRank['id'],
+            'rank' => $seedRank['rank'],
+            'salary' => $seedRank['salary'],
         ], $transformedRecord);
     }
 
     /** @test */
-    public function it_will_transform_a_collection_of_records()
+    public function it_will_transform_a_collection_of_records(): void
     {
-        $seedRanks = SeedRank::factory()->count(3)->make(new Sequence(
+        $seedRanks = SeedRank::factory()->count(3)->sequence(
             ['id' => 'one'],
             ['id' => 'two'],
             ['id' => 'three']
-        ));
+        )->make()->toArray();
 
         $transformer = new SeedRankTransformer();
 
-        $transformedRecords = $transformer->transformCollection($seedRanks->toArray());
+        $transformedRecords = $transformer->transformCollection($seedRanks);
 
         $this->assertEquals([
             [
-                'id' => $seedRanks[0]->id,
-                'rank' => $seedRanks[0]->rank,
-                'salary' => $seedRanks[0]->salary,
+                'id' => $seedRanks[0]['id'],
+                'rank' => $seedRanks[0]['rank'],
+                'salary' => $seedRanks[0]['salary'],
             ],
             [
-                'id' => $seedRanks[1]->id,
-                'rank' => $seedRanks[1]->rank,
-                'salary' => $seedRanks[1]->salary,
+                'id' => $seedRanks[1]['id'],
+                'rank' => $seedRanks[1]['rank'],
+                'salary' => $seedRanks[1]['salary'],
             ],
             [
-                'id' => $seedRanks[2]->id,
-                'rank' => $seedRanks[2]->rank,
-                'salary' => $seedRanks[2]->salary,
+                'id' => $seedRanks[2]['id'],
+                'rank' => $seedRanks[2]['rank'],
+                'salary' => $seedRanks[2]['salary'],
             ],
         ], $transformedRecords);
     }

--- a/tests/Unit/Transformers/V0/SeedTestTransformerTest.php
+++ b/tests/Unit/Transformers/V0/SeedTestTransformerTest.php
@@ -6,61 +6,60 @@ use App\Http\Transformers\V0\SeedTestTransformer;
 use App\Http\Transformers\V0\TestQuestionTransformer;
 use App\Models\SeedTest;
 use App\Models\TestQuestion;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
 class SeedTestTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_transform_a_single_record()
+    public function it_will_transform_a_single_record(): void
     {
         $seedTest = SeedTest::factory()->make([
             'id' => 'some-random-uuid',
             'level' => '1',
             'arbitrary' => 'data',
-        ]);
+        ])->toArray();
 
         $transformer = $this->app->make(SeedTestTransformer::class);
 
-        $transformedRecord = $transformer->transformRecord($seedTest->toArray());
+        $transformedRecord = $transformer->transformRecord($seedTest);
 
         $this->assertEquals([
-            'id' => $seedTest->id,
-            'level' => $seedTest->level,
+            'id' => $seedTest['id'],
+            'level' => $seedTest['level'],
         ], $transformedRecord);
     }
 
     /** @test */
-    public function it_will_transform_a_collection_of_records()
+    public function it_will_transform_a_collection_of_records(): void
     {
-        $seedTests = SeedTest::factory()->count(3)->make(new Sequence(
+        $seedTests = SeedTest::factory()->count(3)->sequence(
             ['id' => 'one'],
             ['id' => 'two'],
             ['id' => 'three']
-        ));
+        )->make()->toArray();
 
         $transformer = $this->app->make(SeedTestTransformer::class);
 
-        $transformedRecords = $transformer->transformCollection($seedTests->toArray());
+        $transformedRecords = $transformer->transformCollection($seedTests);
 
         $this->assertEquals([
             [
-                'id' => $seedTests[0]->id,
-                'level' => $seedTests[0]->level,
+                'id' => $seedTests[0]['id'],
+                'level' => $seedTests[0]['level'],
             ],
             [
-                'id' => $seedTests[1]->id,
-                'level' => $seedTests[1]->level,
+                'id' => $seedTests[1]['id'],
+                'level' => $seedTests[1]['level'],
             ],
             [
-                'id' => $seedTests[2]->id,
-                'level' => $seedTests[2]->level,
+                'id' => $seedTests[2]['id'],
+                'level' => $seedTests[2]['level'],
             ],
         ], $transformedRecords);
     }
 
     /** @test */
-    public function it_will_transform_the_test_questions_records_if_they_are_present()
+    public function it_will_transform_the_test_questions_records_if_they_are_present(): void
     {
         $seedTest = SeedTest::factory()->make(['id' => 'some-uuid'])->toArray();
         $testQuestions = TestQuestion::factory()->count(1)->make([
@@ -87,7 +86,7 @@ class SeedTestTransformerTest extends TestCase
     }
 
     /** @test */
-    public function it_will_include_the_test_questions_key_in_the_event_no_records_are_returned_from_the_relation()
+    public function it_will_include_the_test_questions_key_in_the_event_no_records_are_returned_from_the_relation(): void
     {
         $seedTest = SeedTest::factory()->make(['id' => 'some-uuid'])->toArray();
 

--- a/tests/Unit/Transformers/V0/StatTransformerTest.php
+++ b/tests/Unit/Transformers/V0/StatTransformerTest.php
@@ -4,13 +4,12 @@ namespace Tests\Unit\Transformers\V0;
 
 use App\Http\Transformers\V0\StatTransformer;
 use App\Models\Stat;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
 class StatTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_transform_a_single_record()
+    public function it_will_transform_a_single_record(): void
     {
         $stat = Stat::factory()->make([
             'id' => 'some-random-uuid',
@@ -18,51 +17,51 @@ class StatTransformerTest extends TestCase
             'name' => 'hit points',
             'abbreviation' => 'hp',
             'arbitrary' => 'data',
-        ]);
+        ])->toArray();
 
         $transformer = new StatTransformer();
 
-        $transformedRecord = $transformer->transformRecord($stat->toArray());
+        $transformedRecord = $transformer->transformRecord($stat);
 
         $this->assertEquals([
-            'id' => $stat->id,
-            'sort_id' => $stat->sort_id,
-            'name' => $stat->name,
-            'abbreviation' => $stat->abbreviation,
+            'id' => $stat['id'],
+            'sort_id' => $stat['sort_id'],
+            'name' => $stat['name'],
+            'abbreviation' => $stat['abbreviation'],
         ], $transformedRecord);
     }
 
     /** @test */
-    public function it_will_transform_a_collection_of_records()
+    public function it_will_transform_a_collection_of_records(): void
     {
-        $stats = Stat::factory()->count(3)->make(new Sequence(
+        $stats = Stat::factory()->count(3)->sequence(
             ['id' => 'one'],
             ['id' => 'two'],
             ['id' => 'three']
-        ));
+        )->make()->toArray();
 
         $transformer = new StatTransformer();
 
-        $transformedRecords = $transformer->transformCollection($stats->toArray());
+        $transformedRecords = $transformer->transformCollection($stats);
 
         $this->assertEquals([
             [
-                'id' => $stats[0]->id,
-                'sort_id' => $stats[0]->sort_id,
-                'name' => $stats[0]->name,
-                'abbreviation' => $stats[0]->abbreviation,
+                'id' => $stats[0]['id'],
+                'sort_id' => $stats[0]['sort_id'],
+                'name' => $stats[0]['name'],
+                'abbreviation' => $stats[0]['abbreviation'],
             ],
             [
-                'id' => $stats[1]->id,
-                'sort_id' => $stats[1]->sort_id,
-                'name' => $stats[1]->name,
-                'abbreviation' => $stats[1]->abbreviation,
+                'id' => $stats[1]['id'],
+                'sort_id' => $stats[1]['sort_id'],
+                'name' => $stats[1]['name'],
+                'abbreviation' => $stats[1]['abbreviation'],
             ],
             [
-                'id' => $stats[2]->id,
-                'sort_id' => $stats[2]->sort_id,
-                'name' => $stats[2]->name,
-                'abbreviation' => $stats[2]->abbreviation,
+                'id' => $stats[2]['id'],
+                'sort_id' => $stats[2]['sort_id'],
+                'name' => $stats[2]['name'],
+                'abbreviation' => $stats[2]['abbreviation'],
             ],
         ], $transformedRecords);
     }

--- a/tests/Unit/Transformers/V0/StatusEffectTransformerTest.php
+++ b/tests/Unit/Transformers/V0/StatusEffectTransformerTest.php
@@ -4,13 +4,12 @@ namespace Tests\Unit\Transformers\V0;
 
 use App\Http\Transformers\V0\StatusEffectTransformer;
 use App\Models\StatusEffect;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
 class StatusEffectTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_transform_a_single_record()
+    public function it_will_transform_a_single_record(): void
     {
         $statusEffect = StatusEffect::factory()->make([
             'id' => 'some-random-uuid',
@@ -19,55 +18,55 @@ class StatusEffectTransformerTest extends TestCase
             'type' => 'harmful',
             'description' => 'The Zombie status causes the target to act as if undead. This effect does not wear off on its own.',
             'arbitrary' => 'data',
-        ]);
+        ])->toArray();
 
         $transformer = new StatusEffectTransformer();
 
-        $transformedRecord = $transformer->transformRecord($statusEffect->toArray());
+        $transformedRecord = $transformer->transformRecord($statusEffect);
 
         $this->assertEquals([
-            'id' => $statusEffect->id,
-            'sort_id' => $statusEffect->sort_id,
-            'name' => $statusEffect->name,
-            'type' => $statusEffect->type,
-            'description' => $statusEffect->description,
+            'id' => $statusEffect['id'],
+            'sort_id' => $statusEffect['sort_id'],
+            'name' => $statusEffect['name'],
+            'type' => $statusEffect['type'],
+            'description' => $statusEffect['description'],
         ], $transformedRecord);
     }
 
     /** @test */
-    public function it_will_transform_a_collection_of_records()
+    public function it_will_transform_a_collection_of_records(): void
     {
-        $statusEffects = StatusEffect::factory()->count(3)->make(new Sequence(
+        $statusEffects = StatusEffect::factory()->count(3)->sequence(
             ['id' => 'one', 'sort_id' => 1],
             ['id' => 'two', 'sort_id' => 2],
             ['id' => 'three', 'sort_id' => 3],
-        ));
+        )->make()->toArray();
 
         $transformer = new StatusEffectTransformer();
 
-        $transformedRecords = $transformer->transformCollection($statusEffects->toArray());
+        $transformedRecords = $transformer->transformCollection($statusEffects);
 
         $this->assertEquals([
             [
-                'id' => $statusEffects[0]->id,
-                'sort_id' => $statusEffects[0]->sort_id,
-                'name' => $statusEffects[0]->name,
-                'type' => $statusEffects[0]->type,
-                'description' => $statusEffects[0]->description,
+                'id' => $statusEffects[0]['id'],
+                'sort_id' => $statusEffects[0]['sort_id'],
+                'name' => $statusEffects[0]['name'],
+                'type' => $statusEffects[0]['type'],
+                'description' => $statusEffects[0]['description'],
             ],
             [
-                'id' => $statusEffects[1]->id,
-                'sort_id' => $statusEffects[1]->sort_id,
-                'name' => $statusEffects[1]->name,
-                'type' => $statusEffects[1]->type,
-                'description' => $statusEffects[1]->description,
+                'id' => $statusEffects[1]['id'],
+                'sort_id' => $statusEffects[1]['sort_id'],
+                'name' => $statusEffects[1]['name'],
+                'type' => $statusEffects[1]['type'],
+                'description' => $statusEffects[1]['description'],
             ],
             [
-                'id' => $statusEffects[2]->id,
-                'sort_id' => $statusEffects[2]->sort_id,
-                'name' => $statusEffects[2]->name,
-                'type' => $statusEffects[2]->type,
-                'description' => $statusEffects[2]->description,
+                'id' => $statusEffects[2]['id'],
+                'sort_id' => $statusEffects[2]['sort_id'],
+                'name' => $statusEffects[2]['name'],
+                'type' => $statusEffects[2]['type'],
+                'description' => $statusEffects[2]['description'],
             ],
         ], $transformedRecords);
     }

--- a/tests/Unit/Transformers/V0/TestQuestionTransformerTest.php
+++ b/tests/Unit/Transformers/V0/TestQuestionTransformerTest.php
@@ -6,13 +6,12 @@ use App\Http\Transformers\V0\SeedTestTransformer;
 use App\Http\Transformers\V0\TestQuestionTransformer;
 use App\Models\SeedTest;
 use App\Models\TestQuestion;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Tests\TestCase;
 
 class TestQuestionTransformerTest extends TestCase
 {
     /** @test */
-    public function it_will_transform_a_single_record()
+    public function it_will_transform_a_single_record(): void
     {
         $testQuestion = TestQuestion::factory()->make([
             'id' => 'some-random-uuid',
@@ -21,65 +20,66 @@ class TestQuestionTransformerTest extends TestCase
             'question' => "Potions can restore a GF's HP.",
             'answer' => false,
             'arbitrary' => 'data',
-        ]);
+        ])->toArray();
 
         $transformer = $this->app->make(TestQuestionTransformer::class);
 
-        $transformedRecord = $transformer->transformRecord($testQuestion->toArray());
+        $transformedRecord = $transformer->transformRecord($testQuestion);
 
         $this->assertEquals([
-            'id' => $testQuestion->id,
-            'sort_id' => $testQuestion->sort_id,
-            'seed_test_id' => $testQuestion->seed_test_id,
-            'question_number' => $testQuestion->question_number,
-            'question' => $testQuestion->question,
-            'answer' => $testQuestion->answer,
+            'id' => $testQuestion['id'],
+            'sort_id' => $testQuestion['sort_id'],
+            'seed_test_id' => $testQuestion['seed_test_id'],
+            'question_number' => $testQuestion['question_number'],
+            'question' => $testQuestion['question'],
+            'answer' => $testQuestion['answer'],
         ], $transformedRecord);
     }
 
     /** @test */
-    public function it_will_transform_a_collection_of_records()
+    public function it_will_transform_a_collection_of_records(): void
     {
-        $testQuestions = TestQuestion::factory()->count(3)->make(new Sequence(
+        $testQuestions = TestQuestion::factory()->count(3)->sequence(
             ['id' => 'one', 'sort_id' => 1],
             ['id' => 'two', 'sort_id' => 2],
             ['id' => 'three', 'sort_id' => 3]
-        ));
+        )->make()->toArray();
 
         $transformer = $this->app->make(TestQuestionTransformer::class);
 
-        $transformedRecords = $transformer->transformCollection($testQuestions->toArray());
+        $transformedRecords = $transformer->transformCollection($testQuestions);
 
+        $this->assertCount(3, $testQuestions);
         $this->assertEquals([
             [
-                'id' => $testQuestions[0]->id,
-                'sort_id' => $testQuestions[0]->sort_id,
-                'seed_test_id' => $testQuestions[0]->seed_test_id,
-                'question_number' => $testQuestions[0]->question_number,
-                'question' => $testQuestions[0]->question,
-                'answer' => $testQuestions[0]->answer,
+                'id' => $testQuestions[0]['id'],
+                'sort_id' => $testQuestions[0]['sort_id'],
+                'seed_test_id' => $testQuestions[0]['seed_test_id'],
+                'question_number' => $testQuestions[0]['question_number'],
+                'question' => $testQuestions[0]['question'],
+                'answer' => $testQuestions[0]['answer'],
             ],
             [
-                'id' => $testQuestions[1]->id,
-                'sort_id' => $testQuestions[1]->sort_id,
-                'seed_test_id' => $testQuestions[1]->seed_test_id,
-                'question_number' => $testQuestions[1]->question_number,
-                'question' => $testQuestions[1]->question,
-                'answer' => $testQuestions[1]->answer,
+                'id' => $testQuestions[1]['id'],
+                'sort_id' => $testQuestions[1]['sort_id'],
+                'seed_test_id' => $testQuestions[1]['seed_test_id'],
+                'question_number' => $testQuestions[1]['question_number'],
+                'question' => $testQuestions[1]['question'],
+                'answer' => $testQuestions[1]['answer'],
             ],
             [
-                'id' => $testQuestions[2]->id,
-                'sort_id' => $testQuestions[2]->sort_id,
-                'seed_test_id' => $testQuestions[2]->seed_test_id,
-                'question_number' => $testQuestions[2]->question_number,
-                'question' => $testQuestions[2]->question,
-                'answer' => $testQuestions[2]->answer,
+                'id' => $testQuestions[2]['id'],
+                'sort_id' => $testQuestions[2]['sort_id'],
+                'seed_test_id' => $testQuestions[2]['seed_test_id'],
+                'question_number' => $testQuestions[2]['question_number'],
+                'question' => $testQuestions[2]['question'],
+                'answer' => $testQuestions[2]['answer'],
             ],
         ], $transformedRecords);
     }
 
     /** @test */
-    public function it_will_transform_the_seed_test_record_if_it_is_present()
+    public function it_will_transform_the_seed_test_record_if_it_is_present(): void
     {
         $seedTest = SeedTest::factory()->make(['id' => 'some-uuid'])->toArray();
         $testQuestion = TestQuestion::factory()->make([
@@ -106,7 +106,7 @@ class TestQuestionTransformerTest extends TestCase
     }
 
     /** @test */
-    public function it_will_include_the_seed_test_key_in_the_event_no_records_are_returned_from_the_relation()
+    public function it_will_include_the_seed_test_key_in_the_event_no_records_are_returned_from_the_relation(): void
     {
         $testQuestion = TestQuestion::factory()->make([
             'id' => 'some-random-uuid',


### PR DESCRIPTION
Includes PHPStan support and cleans up the codebase to follow suit with level 8 standards. This applies to the `app/` folder, as well as the `database/` and `tests/` folders. Changes are relatively minor, albeit they've touched just about every source file to outline things such as updated docblocks and minor type changes. The `composer.json` file was updated to include the `nunomaduro/larastan` library rather than `phpstan/phpstan` directly as larastan inherits this dependency and takes care of outlining all of the magic present within Laravel.