### PR TITLE
style: update docblock comments to align with phpstan

### DIFF
--- a/app/Contracts/Services/Search/SearchService.php
+++ b/app/Contracts/Services/Search/SearchService.php
@@ -7,9 +7,9 @@ interface SearchService
     /**
      * Search the system for a subset of records.
      *
-     * @param string   $query   The string by which to search
-     * @param string[] $only    The resources that should be searched
-     * @param string[] $exclude The resources that should be excluded from the search
+     * @param string             $query   The string by which to search
+     * @param array<int, string> $only    The resources that should be searched
+     * @param array<int, string> $exclude The resources that should be excluded from the search
      *
      * @return array<string, array<int, array<string, mixed>>>
      */

--- a/app/Models/Element.php
+++ b/app/Models/Element.php
@@ -32,7 +32,7 @@ class Element extends SearchableModel
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $visible = [
         'id',
@@ -54,7 +54,7 @@ class Element extends SearchableModel
     /**
      * The fields that should be searchable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $searchableFields = [
         'name',
@@ -63,7 +63,7 @@ class Element extends SearchableModel
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $filterableFields = [
         'name',

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -37,14 +37,14 @@ class Model extends EloquentModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $fillable = [];
 
     /**
      * The attributes that should be hidden for arrays.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $hidden = [
         'created_at',

--- a/app/Models/SearchableModel.php
+++ b/app/Models/SearchableModel.php
@@ -11,14 +11,14 @@ class SearchableModel extends Model
     /**
      * The fields that should be searchable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $searchableFields = [];
 
     /**
      * Get the fields that should be searchable.
      *
-     * @return string[]
+     * @return array<int, string>
      */
     public function getSearchableFields(): array
     {

--- a/app/Models/SeedRank.php
+++ b/app/Models/SeedRank.php
@@ -32,7 +32,7 @@ class SeedRank extends SearchableModel
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $visible = [
         'id',
@@ -54,7 +54,7 @@ class SeedRank extends SearchableModel
     /**
      * The fields that should be searchable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $searchableFields = [
         'rank',

--- a/app/Models/SeedTest.php
+++ b/app/Models/SeedTest.php
@@ -33,7 +33,7 @@ class SeedTest extends SearchableModel
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $visible = [
         'id',
@@ -54,7 +54,7 @@ class SeedTest extends SearchableModel
     /**
      * The fields that should be searchable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $searchableFields = [
         'level',
@@ -63,7 +63,7 @@ class SeedTest extends SearchableModel
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $filterableFields = [
         'level',
@@ -72,7 +72,7 @@ class SeedTest extends SearchableModel
     /**
      * The relations that are available to include with the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $availableIncludes = [
         'testQuestions',
@@ -81,7 +81,7 @@ class SeedTest extends SearchableModel
     /**
      * The default relations to include with the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $defaultIncludes = [];
 

--- a/app/Models/Stat.php
+++ b/app/Models/Stat.php
@@ -32,7 +32,7 @@ class Stat extends Model
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $visible = [
         'id',
@@ -56,7 +56,7 @@ class Stat extends Model
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $filterableFields = [];
 }

--- a/app/Models/StatusEffect.php
+++ b/app/Models/StatusEffect.php
@@ -32,7 +32,7 @@ class StatusEffect extends SearchableModel
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $visible = [
         'id',
@@ -58,7 +58,7 @@ class StatusEffect extends SearchableModel
     /**
      * The fields that should be searchable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $searchableFields = [
         'name',
@@ -69,7 +69,7 @@ class StatusEffect extends SearchableModel
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $filterableFields = [
         'name',

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -33,7 +33,7 @@ class TestQuestion extends SearchableModel
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $visible = [
         'id',
@@ -62,7 +62,7 @@ class TestQuestion extends SearchableModel
     /**
      * The fields that should be searchable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $searchableFields = [
         'question_number',
@@ -73,7 +73,7 @@ class TestQuestion extends SearchableModel
     /**
      * The fields that can be used as a filter on the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $filterableFields = [
         'question_number',
@@ -84,7 +84,7 @@ class TestQuestion extends SearchableModel
     /**
      * The relations that are available to include with the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $availableIncludes = [
         'seedTest',
@@ -93,7 +93,7 @@ class TestQuestion extends SearchableModel
     /**
      * The default relations to include with the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $defaultIncludes = [];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,7 +14,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',
@@ -25,7 +25,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for arrays.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $hidden = [
         'password',
@@ -35,7 +35,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be cast to native types.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $casts = [
         'email_verified_at' => 'datetime',

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -9,7 +9,7 @@ class AuthServiceProvider extends ServiceProvider
     /**
      * The policy mappings for the application.
      *
-     * @var array<string, string>
+     * @var array<class-string, class-string>
      */
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',

--- a/app/Services/Search/MeilisearchService.php
+++ b/app/Services/Search/MeilisearchService.php
@@ -28,9 +28,9 @@ class MeilisearchService implements SearchService
     /**
      * Search the system for a subset of records.
      *
-     * @param string   $query   The string by which to search
-     * @param string[] $only    The resources that should be searched
-     * @param string[] $exclude The resources that should be excluded from the search
+     * @param string             $query   The string by which to search
+     * @param array<int, string> $only    The resources that should be searched
+     * @param array<int, string> $exclude The resources that should be excluded from the search
      *
      * @return array<string, array<int, array<string, mixed>>>
      */
@@ -87,7 +87,7 @@ class MeilisearchService implements SearchService
     /**
      * Pluck only the given resources from the ones available.
      *
-     * @param string[] $only The resources that should be searched
+     * @param array<int, string> $only The resources that should be searched
      *
      * @return array<string, string>
      */
@@ -102,7 +102,7 @@ class MeilisearchService implements SearchService
     /**
      * Exclude the given resources from the ones available.
      *
-     * @param string[] $exclude The resources that should be excluded from the search
+     * @param array<int, string> $exclude The resources that should be excluded from the search
      *
      * @return array<string, string>
      */

--- a/app/Traits/LoadsRelationsThroughServices.php
+++ b/app/Traits/LoadsRelationsThroughServices.php
@@ -10,21 +10,21 @@ trait LoadsRelationsThroughServices
     /**
      * The relations that are available to include with the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $availableIncludes = [];
 
     /**
      * The default relations to include with the resource.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected $defaultIncludes = [];
 
     /**
      * Get the relations that are available to include with the resource.
      *
-     * @return string[]
+     * @return array<int, string>
      */
     public function getAvailableIncludes(): array
     {
@@ -34,7 +34,7 @@ trait LoadsRelationsThroughServices
     /**
      * Get the default relations to include with the resource.
      *
-     * @return string[]
+     * @return array<int, string>
      */
     public function getDefaultIncludes(): array
     {
@@ -49,7 +49,7 @@ trait LoadsRelationsThroughServices
      *
      * @param string $includes The requested includes in csv format
      *
-     * @return string[]
+     * @return array<int, string>
      */
     public function parseIncludes(string $includes): array
     {


### PR DESCRIPTION
It seems PHPStan doesn't like when comments are formatted differently for overridden items. This mainly addresses the format of `string[]` vs `array<int, string>`. Some Laravel docblocks specify `array<int, string>` instead of `string[]`, so the codebase has been updated to reflect the proper syntax while also standardizing it across other areas in the process.