### PR TITLE
ci: allow safe directory for build process

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -48,6 +48,7 @@ jobs:
           yarn global add standard-version
           git config --global user.name "tunabot"
           git config --global user.email rbennett1106@gmail.com
+          git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a workaround to combat the security flaw found within git recently (CVE-2022-24765). Allowing the GitHub workspace to be listed as a safe directory will allow us to checkout the code from within a docker container.