### PR TITLE
chore: update docker manifest syntax and include refactors with versioning

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -7,6 +7,7 @@
     { "type": "feat", "section": "Features", "hidden": false },
     { "type": "fix", "section": "Bug Fixes", "hidden": false },
     { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "refactor", "section": "Refactor", "hidden": true },
     { "type": "test", "section": "Tests", "hidden": true },
     { "type": "build", "section": "Build System", "hidden": true },
     { "type": "ci", "section": "CI", "hidden": true },

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ services:
     environment:
       VIRTUAL_HOST: meilisearch.local
       MEILI_MASTER_KEY: secret
-      MEILI_NO_ANALYTICS: true
+      MEILI_NO_ANALYTICS: 'true'
     networks:
       - uptilt
       - viiidb

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,5 +16,5 @@ services:
 
 networks:
   viiidb:
-    external:
-      name: viiidb
+    name: viiidb
+    external: true


### PR DESCRIPTION
Updates the `docker-compose.yaml` manifest with an API schema that matches the `3.5` spec. This only impacts the `networks` section of the manifest to specify an external network properly.

The meilisearch container started throwing errors regarding the value present in the `MEILI_NO_ANALYTICS` environment variable with the newest Docker version. This update ensures that the documentation references the proper format that Docker expects now.

Also updates the `.versionrc` file to include the `refactor` type with versioning.