### PR TITLE
test: remove import alias

### DIFF
--- a/tests/Unit/Models/ElementTest.php
+++ b/tests/Unit/Models/ElementTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Element;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class ElementTest extends TestCase
 {

--- a/tests/Unit/Models/ModelTest.php
+++ b/tests/Unit/Models/ModelTest.php
@@ -8,7 +8,7 @@ use App\Traits\OrdersQueryResults;
 use App\Traits\Uuids;
 use App\Traits\VerifiesIncludes;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class ModelTest extends TestCase
 {

--- a/tests/Unit/Models/SeedRankTest.php
+++ b/tests/Unit/Models/SeedRankTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\SeedRank;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class SeedRankTest extends TestCase
 {

--- a/tests/Unit/Models/SeedTestTest.php
+++ b/tests/Unit/Models/SeedTestTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\SeedTest;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class SeedTestTest extends TestCase
 {

--- a/tests/Unit/Models/StatTest.php
+++ b/tests/Unit/Models/StatTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Stat;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class StatTest extends TestCase
 {

--- a/tests/Unit/Models/StatusEffectTest.php
+++ b/tests/Unit/Models/StatusEffectTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\StatusEffect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class StatusEffectTest extends TestCase
 {

--- a/tests/Unit/Models/TestQuestionTest.php
+++ b/tests/Unit/Models/TestQuestionTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 
 class TestQuestionTest extends TestCase
 {


### PR DESCRIPTION
This removes the `use Tests\TestCase as TestCase` from the model tests. Not sure how it got there, but it doesn't need to be imported with an alias that matches the class name.