### PR TITLE
docs: remove unused network from resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ services:
       MEILI_MASTER_KEY: secret
       MEILI_NO_ANALYTICS: 'true'
     networks:
-      - uptilt
       - viiidb
 ```
 


### PR DESCRIPTION
When copying the Meilisearch container from my local configuration, I mistakenly left the `uptilt` network on the container. This is not needed for the scope of the documentation.