### PR TITLE
feat: add location resource

### DIFF
--- a/app/Console/Commands/SeedSearchService.php
+++ b/app/Console/Commands/SeedSearchService.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Element;
 use App\Models\Item;
+use App\Models\Location;
 use App\Models\SearchableModel;
 use App\Models\SeedRank;
 use App\Models\SeedTest;
@@ -40,6 +41,7 @@ class SeedSearchService extends Command
         StatusEffect::class,
         TestQuestion::class,
         Item::class,
+        Location::class,
     ];
 
     /**

--- a/app/Contracts/Services/LocationService.php
+++ b/app/Contracts/Services/LocationService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Contracts\Services;
+
+interface LocationService extends ModelService
+{
+}

--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -74,6 +74,19 @@ class HealthCheckController extends Controller
                     'url' => "{$baseUrl}/v{$currentApiVersion}/items",
                     'query_parameters' => [],
                 ],
+                'locations' => [
+                    'url' => "{$baseUrl}/v{$currentApiVersion}/locations",
+                    'query_parameters' => [
+                        'include' => [
+                            'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                            'options' => [
+                                'region',
+                                'parent',
+                                'locations',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ]);
     }

--- a/app/Http/Controllers/V0/LocationController.php
+++ b/app/Http/Controllers/V0/LocationController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\LocationService;
+use App\Http\Controllers\ResourceController;
+use App\Http\Transformers\V0\LocationTransformer;
+
+class LocationController extends ResourceController
+{
+    /**
+     * Create a new LocationController instance.
+     *
+     * @param LocationService     $locationService     The Service that will process the request
+     * @param LocationTransformer $locationTransformer The Transformer that will standardize the response
+     */
+    public function __construct(LocationService $locationService, LocationTransformer $locationTransformer)
+    {
+        $this->service = $locationService;
+        $this->transformer = $locationTransformer;
+    }
+}

--- a/app/Http/Transformers/V0/LocationTransformer.php
+++ b/app/Http/Transformers/V0/LocationTransformer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Transformers\V0;
+
+use App\Http\Transformers\RecordTransformer;
+
+class LocationTransformer extends RecordTransformer
+{
+    /**
+     * Transforms an individual record to standardize the output.
+     *
+     * @param array<string, mixed> $record The record to be transformed
+     *
+     * @return array<string, mixed>
+     */
+    public function transformRecord(array $record): array
+    {
+        $data = [
+            'id' => $record['id'],
+            'region_id' => $record['region_id'],
+            'parent_id' => $record['parent_id'],
+            'sort_id' => $record['sort_id'],
+            'slug' => $record['slug'],
+            'name' => $record['name'],
+            'notes' => $record['notes'],
+        ];
+
+        if (array_key_exists('region', $record)) {
+            $data['region'] = $record['region']
+                ? $this->getLocationTransformer()->transformRecord($record['region'])
+                : null;
+        }
+
+        if (array_key_exists('parent', $record)) {
+            $data['parent'] = $record['parent']
+                ? $this->getLocationTransformer()->transformRecord($record['parent'])
+                : null;
+        }
+
+        if (array_key_exists('locations', $record)) {
+            $data['locations'] = $record['locations']
+                ? $this->getLocationTransformer()->transformCollection($record['locations'])
+                : [];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Create a new LocationTransformer instance.
+     *
+     * @return LocationTransformer
+     */
+    protected function getLocationTransformer(): LocationTransformer
+    {
+        return new self();
+    }
+}

--- a/app/Http/Transformers/V0/SearchTransformer.php
+++ b/app/Http/Transformers/V0/SearchTransformer.php
@@ -19,6 +19,7 @@ class SearchTransformer
         'status_effects' => StatusEffectTransformer::class,
         'test_questions' => TestQuestionTransformer::class,
         'items' => ItemTransformer::class,
+        'locations' => LocationTransformer::class,
     ];
 
     /**

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Location extends SearchableModel
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'locations';
+
+    /**
+     * The default field used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByField = 'sort_id';
+
+    /**
+     * The default direction used to order query results by.
+     *
+     * @var string
+     */
+    protected $orderByDirection = 'asc';
+
+    /**
+     * The attributes that should be visible in serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $visible = [
+        'id',
+        'region_id',
+        'parent_id',
+        'sort_id',
+        'slug',
+        'name',
+        'notes',
+        'region',
+        'parent',
+        'locations',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'id' => 'string',
+        'region_id' => 'string',
+        'parent_id' => 'string',
+        'sort_id' => 'integer',
+        'slug' => 'string',
+        'name' => 'string',
+        'notes' => 'string',
+    ];
+
+    /**
+     * The fields that should be searchable.
+     *
+     * @var array<int, string>
+     */
+    protected $searchableFields = [
+        'slug',
+        'name',
+        'notes',
+    ];
+
+    /**
+     * The fields that can be used as a filter on the resource.
+     *
+     * @var string[]
+     */
+    protected $filterableFields = [
+        'slug',
+        'name',
+        'notes',
+    ];
+
+    /**
+     * The relations that are available to include with the resource.
+     *
+     * @var array<int, string>
+     */
+    protected $availableIncludes = [
+        'region',
+        'parent',
+        'locations',
+    ];
+
+    /**
+     * The default relations to include with the resource.
+     *
+     * @var array<int, string>
+     */
+    protected $defaultIncludes = [];
+
+    /*
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    /**
+     * The region that the record belongs to.
+     *
+     * @return BelongsTo<Location, Location>
+     */
+    public function region(): BelongsTo
+    {
+        return $this->belongsTo(Location::class, 'region_id', 'id');
+    }
+
+    /**
+     * The parent location that the record belongs to.
+     *
+     * @return BelongsTo<Location, Location>
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Location::class, 'parent_id', 'id');
+    }
+
+    /**
+     * The child locations that are associated with the record.
+     *
+     * @return HasMany<Location>
+     */
+    public function locations(): HasMany
+    {
+        return $this->hasMany(Location::class, 'parent_id', 'id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -47,6 +47,11 @@ class AppServiceProvider extends ServiceProvider
             \App\Services\ItemService::class
         );
 
+        $this->app->bind(
+            \App\Contracts\Services\LocationService::class,
+            \App\Services\LocationService::class
+        );
+
         $this->app->singleton(CaptureInboundRequest::class);
     }
 

--- a/app/Services/LocationService.php
+++ b/app/Services/LocationService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Services\LocationService as LocationServiceContract;
+use App\Models\Location;
+
+class LocationService extends ModelService implements LocationServiceContract
+{
+    /**
+     * Create a new LocationService instance.
+     *
+     * @param Location $model The instance of the model to use for the service
+     */
+    public function __construct(Location $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/Services/Search/MeilisearchService.php
+++ b/app/Services/Search/MeilisearchService.php
@@ -5,6 +5,7 @@ namespace App\Services\Search;
 use App\Contracts\Services\Search\SearchService;
 use App\Models\Element;
 use App\Models\Item;
+use App\Models\Location;
 use App\Models\SearchableModel;
 use App\Models\SeedRank;
 use App\Models\SeedTest;
@@ -22,6 +23,7 @@ class MeilisearchService implements SearchService
      */
     protected $searchable = [
         'items' => Item::class,
+        'locations' => Location::class,
         'seed_tests' => SeedTest::class,
         'test_questions' => TestQuestion::class,
         'status_effects' => StatusEffect::class,

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Location;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Location>
+ */
+class LocationFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Location::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition(): array
+    {
+        return [
+            'region_id' => null,
+            'parent_id' => null,
+            'sort_id' => $this->faker->unique()->numberBetween(1, 500),
+            'slug' => $this->faker->slug,
+            'name' => $this->faker->words(3, true),
+            'notes' => $this->faker->sentence,
+        ];
+    }
+}

--- a/database/migrations/2022_04_28_022332_create_locations_table.php
+++ b/database/migrations/2022_04_28_022332_create_locations_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLocationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('locations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('region_id')->nullable();
+            $table->uuid('parent_id')->nullable();
+            $table->integer('sort_id')->unique();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('locations');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,5 +20,6 @@ class DatabaseSeeder extends Seeder
         $this->call(StatsTableSeeder::class);
         $this->call(ElementsTableSeeder::class);
         $this->call(ItemsTableSeeder::class);
+        $this->call(LocationsTableSeeder::class);
     }
 }

--- a/database/seeders/LocationsTableSeeder.php
+++ b/database/seeders/LocationsTableSeeder.php
@@ -1,0 +1,1332 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Location;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+use Webpatser\Uuid\Uuid;
+
+class LocationsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $regions = [
+            ['name' => 'Balamb (Region)'],
+            ['name' => 'Dollet (Region)'],
+            ['name' => 'Timber (Region)'],
+            ['name' => 'Galbadia (Region)'],
+            ['name' => 'Winhill (Region)'],
+            ['name' => 'International (Region)'],
+            ['name' => 'Trabia (Region)'],
+            ['name' => 'Centra (Region)'],
+            ['name' => 'Esthar (Region)'],
+            ['name' => 'Wilderness (Region)'],
+            ['name' => 'None'],
+        ];
+
+        $balambRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Balamb - Alcauld Plains',
+                'parent' => 'balamb-region',
+            ],
+            [
+                'name' => 'Balamb - Galug Mountains',
+                'parent' => 'balamb-region',
+            ],
+            [
+                'name' => 'Balamb - Raha Cape',
+                'parent' => 'balamb-region',
+            ],
+            [
+                'name' => 'Balamb - Rinaul Cost',
+                'parent' => 'balamb-region',
+            ],
+            // Overworld Locations.
+            [
+                'name' => 'Fire Cavern',
+                'parent' => 'balamb-alcauld-plains',
+            ],
+            // Towns.
+            [
+                'name' => 'Balamb Town',
+                'parent' => 'balamb-alcauld-plains',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Balamb - Town Square',
+                'parent' => 'balamb-town',
+            ],
+            [
+                'name' => 'Balamb - Residence',
+                'parent' => 'balamb-town',
+            ],
+            [
+                'name' => "Balamb -  The Dincht's",
+                'parent' => 'balamb-town',
+            ],
+            [
+                'name' => 'Balamb - Station Yard',
+                'parent' => 'balamb-town',
+            ],
+            [
+                'name' => 'Balamb Hotel',
+                'parent' => 'balamb-town',
+            ],
+            [
+                'name' => 'Balamb Harbor',
+                'parent' => 'balamb-town',
+            ],
+            [
+                'name' => 'Balamb Garden',
+                'parent' => 'balamb-alcauld-plains',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'B-Garden - Front Gate',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Hall',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Hallway',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Infirmary',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Quad',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Cafeteria',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Dormitory Single',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Dormitory Double',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Parking Lot',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Training Center',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Secret Area',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Library',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - 2F Hallway',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Classroom',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Deck',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => "B-Garden - Headmaster's Office",
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Ballroom',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - Master Room',
+                'parent' => 'balamb-garden',
+            ],
+            [
+                'name' => 'B-Garden - MD Level',
+                'parent' => 'balamb-garden',
+            ],
+        ];
+
+        $dolletRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Dollet - Hasberry Plains',
+                'parent' => 'dollet-region',
+            ],
+            [
+                'name' => 'Dollet - Holy Glory Cape',
+                'parent' => 'dollet-region',
+            ],
+            [
+                'name' => 'Dollet - Long Horn Island',
+                'parent' => 'dollet-region',
+            ],
+            [
+                'name' => 'Dollet - Malgo Peninsula',
+                'parent' => 'dollet-region',
+            ],
+            // Towns.
+            [
+                'name' => 'Dollet',
+                'parent' => 'dollet-hasberry-plains',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Dollet - Town Square',
+                'parent' => 'dollet',
+            ],
+            [
+                'name' => 'Dollet - Residence',
+                'parent' => 'dollet',
+            ],
+            [
+                'name' => 'Dollet - Lapin Beach',
+                'parent' => 'dollet',
+            ],
+            [
+                'name' => 'Dollet Harbor',
+                'parent' => 'dollet',
+            ],
+            [
+                'name' => 'Dollet Pub',
+                'parent' => 'dollet',
+            ],
+            [
+                'name' => 'Dollet Hotel',
+                'parent' => 'dollet',
+            ],
+            // Special Areas.
+            [
+                'name' => 'Dollet - Comm Tower',
+                'parent' => 'dollet',
+                'notes' => 'This area is only accessible during the SeeD training mission.',
+            ],
+            [
+                'name' => 'Dollet - Mountain Hideout',
+                'parent' => 'dollet',
+                'notes' => 'This area is only accessible during the SeeD training mission.',
+            ],
+        ];
+
+        $timberRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Timber - Lanker Plains',
+                'parent' => 'timber-region',
+            ],
+            [
+                'name' => 'Timber - Mandy Beach',
+                'parent' => 'timber-region',
+            ],
+            [
+                'name' => 'Timber - Nanchucket Island',
+                'parent' => 'timber-region',
+            ],
+            [
+                'name' => 'Timber - Obel Lake',
+                'parent' => 'timber-region',
+            ],
+            [
+                'name' => 'Timber - Roshfall Forest',
+                'parent' => 'timber-region',
+            ],
+            [
+                'name' => 'Timber - Shenand Island',
+                'parent' => 'timber-region',
+            ],
+            [
+                'name' => 'Timber - Yaulny Canyon',
+                'parent' => 'timber-region',
+            ],
+            // Towns.
+            [
+                'name' => 'Timber',
+                'parent' => 'timber-region',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Timber - City Square',
+                'parent' => 'timber',
+            ],
+            [
+                'name' => 'Timber - Editorial Department',
+                'parent' => 'timber',
+            ],
+            [
+                'name' => 'Timber - Residence (1)',
+                'parent' => 'timber',
+                'notes' => 'This area is next to the Timber Maniacs building and is the home that shelters the party after the TV broadcast.',
+            ],
+            [
+                'name' => 'Timber - Residence (2)',
+                'parent' => 'timber',
+                'notes' => "This area is near the train tracks on the outskirts of town and is where the Owl's Tear is found.",
+            ],
+            [
+                'name' => 'Timber - TV Screen',
+                'parent' => 'timber',
+            ],
+            [
+                'name' => 'Timber TV Station',
+                'parent' => 'timber',
+            ],
+            [
+                'name' => 'Timber Hotel',
+                'parent' => 'timber',
+            ],
+            [
+                'name' => 'Timber Pub',
+                'parent' => 'timber',
+            ],
+            // Special Areas.
+            [
+                'name' => "Timber - Forest Owl's Base",
+                'parent' => 'timber',
+                'notes' => 'This area is only available during the Forest Owls mission when first arriving in Timber.',
+            ],
+            [
+                'name' => 'Timber - Train',
+                'parent' => 'timber',
+                'notes' => 'This area is only available during the Forest Owls mission when first arriving in Timber, and is only used for the Gerogero boss fight.',
+            ],
+            [
+                'name' => 'Timber Forest',
+                'parent' => 'timber-region',
+                'notes' => "This area is only accessible via Laguna's dream sequence.",
+            ],
+        ];
+
+        $galbadiaRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Galbadia - Dingo Desert',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Galbadia - Gotland Peninsula',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Galbadia - Lallapalooza Canyon',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Galbadia - Monterosa Plateau',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Galbadia - Rem Archipelago',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Galbadia - Wilburn Hill',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Great Plains of Galbadia',
+                'parent' => 'galbadia-region',
+            ],
+            [
+                'name' => 'Island Closest to Hell',
+                'parent' => 'galbadia-region',
+            ],
+            // Overworld Locations.
+            [
+                'name' => 'G-Garden - Station',
+                'parent' => 'galbadia-monterosa-plateau',
+            ],
+            [
+                'name' => 'Tomb of the Unknown King',
+                'parent' => 'galbadia-gotland-peninsula',
+            ],
+            [
+                'name' => 'Galbadia D-District Prison',
+                'parent' => 'galbadia-dingo-desert',
+            ],
+            [
+                'name' => 'Galbadia Missile Base',
+                'parent' => 'great-plains-of-galbadia',
+            ],
+            // Towns.
+            [
+                'name' => 'Deling City',
+                'parent' => 'great-plains-of-galbadia',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Deling City - City Square',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling City - Hotel',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling City - Club',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling City - Gateway',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling - Presidential Residence',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling City - Parade',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => "Deling City - Caraway's Mansion",
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling City - Sewer',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Deling City - Station Yard',
+                'parent' => 'deling-city',
+            ],
+            [
+                'name' => 'Galbadia Garden',
+                'parent' => 'deling-city',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Galbadia Garden - Front Gate',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Hall',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Hallway',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Reception Room',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Classroom',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Clubroom',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Dormitory',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Elevator Hall',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Back Entrance',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Stand',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Gymnasium',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Athletic Track',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Master Room',
+                'parent' => 'galbadia-garden',
+            ],
+            [
+                'name' => 'G-Garden - Auditorium',
+                'parent' => 'galbadia-garden',
+            ],
+            // Special Areas.
+            [
+                'name' => 'Desert',
+                'parent' => 'galbadia-dingo-desert',
+                'notes' => 'This area is where the party splits up after the prison escape at the beginning of disc 2.',
+            ],
+        ];
+
+        $winhillRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Winhill - Humphrey Archipelago',
+                'parent' => 'winhill-region',
+            ],
+            [
+                'name' => 'Winhill - Winhill Bluffs',
+                'parent' => 'winhill-region',
+            ],
+            // Towns.
+            [
+                'name' => 'Winhill',
+                'parent' => 'winhill-winhill-bluffs',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Winhill Village',
+                'parent' => 'winhill',
+            ],
+            [
+                'name' => 'Winhill - Hotel',
+                'parent' => 'winhill',
+            ],
+            [
+                'name' => 'Winhill Pub',
+                'parent' => 'winhill',
+            ],
+            [
+                'name' => 'Winhill - Mansion',
+                'parent' => 'winhill',
+            ],
+            [
+                'name' => 'Winhill Vacant House',
+                'parent' => 'winhill',
+            ],
+            [
+                'name' => 'Winhill - Residence (1)',
+                'parent' => 'winhill',
+                'notes' => 'This area is located near the hotel and is home to an old couple.',
+            ],
+            [
+                'name' => 'Winhill - Residence (2)',
+                'parent' => 'winhill',
+                'notes' => 'This area is located in the middle of town, past the chocobo crossing.',
+            ],
+        ];
+
+        $internationalRegionLocations = [
+            // Towns.
+            [
+                'name' => "Fisherman's Horizon",
+                'slug' => "Fisherman's Horizon (1)",
+                'parent' => 'international-region',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'B-Garden - Deck (2)',
+                'parent' => 'fishermans-horizon-1',
+                'notes' => "This area is the section of Balamb Garden that connects to the Factory in Fisherman's Horizon.",
+            ],
+            [
+                'name' => 'FH - Factory',
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => "Fisherman's Horizon",
+                'slug' => "Fisherman's Horizon (2)",
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => 'FH - Sun Panel',
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => "FH - Mayor's House",
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => 'FH - Festival Grounds',
+                'parent' => 'fishermans-horizon-1',
+                'notes' => "This area is only available during the festival that takes place in Fisherman's Horizon",
+            ],
+            [
+                'name' => 'FH - Residential Area',
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => 'FH - Hotel',
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => 'FH - Residence',
+                'parent' => 'fishermans-horizon-1',
+                'notes' => 'This area is home to Grease Monkey.',
+            ],
+            [
+                'name' => 'FH - Station Yard',
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => 'Horizon Bridge',
+                'parent' => 'fishermans-horizon-1',
+            ],
+            [
+                'name' => 'Seaside Station',
+                'parent' => 'fishermans-horizon-1',
+            ],
+        ];
+
+        $trabiaRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Trabia - Albatross Archipelago',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Hawkwind Plains',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Bika Snowfield',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Thor Peninsula',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Heath Peninsula',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Trabia Crater',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Eldbeak Peninsula',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Sorbald Snowfield',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Winter Island',
+                'parent' => 'trabia-region',
+            ],
+            [
+                'name' => 'Trabia - Vienne Mountains',
+                'parent' => 'trabia-region',
+            ],
+            // Overworld Locations.
+            [
+                'name' => 'Trabia Canyon',
+                'parent' => 'trabia-vienne-mountains',
+            ],
+            // Towns.
+            [
+                'name' => 'Shumi Village',
+                'parent' => 'trabia-winter-island',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Mystery Dome',
+                'parent' => 'shumi-village',
+            ],
+            [
+                'name' => 'Shumi Village - Desert Village',
+                'parent' => 'shumi-village',
+            ],
+            [
+                'name' => 'Shumi Village - Elevator',
+                'parent' => 'shumi-village',
+            ],
+            [
+                'name' => 'Shumi Village - Village',
+                'parent' => 'shumi-village',
+            ],
+            [
+                'name' => 'Shumi Village - Hotel',
+                'parent' => 'shumi-village',
+            ],
+            [
+                'name' => 'Shumi Village - Residence (1)',
+                'parent' => 'shumi-village',
+                'notes' => 'This is the area where the occupant is washing dishes.',
+            ],
+            [
+                'name' => 'Shumi Village - Residence (2)',
+                'parent' => 'shumi-village',
+                'notes' => 'This is the area with the artisans and the statue of Laguna.',
+            ],
+            [
+                'name' => 'Shumi Village - Residence (3)',
+                'parent' => 'shumi-village',
+                'notes' => 'This is the area where the elder resides.',
+            ],
+            [
+                'name' => 'Trabia Garden',
+                'parent' => 'trabia-bika-snowfield',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Trabia Garden - Front Gate',
+                'parent' => 'trabia-garden',
+            ],
+            [
+                'name' => 'T-Garden - Cemetery',
+                'parent' => 'trabia-garden',
+            ],
+            [
+                'name' => 'T-Garden - Garage',
+                'parent' => 'trabia-garden',
+            ],
+            [
+                'name' => 'T-Garden - Classroom',
+                'parent' => 'trabia-garden',
+            ],
+            [
+                'name' => 'T-Garden - Festival Stage',
+                'parent' => 'trabia-garden',
+            ],
+            [
+                'name' => 'T-Garden - Athletic Ground',
+                'parent' => 'trabia-garden',
+            ],
+            // Special Areas.
+            [
+                'name' => "Chocobo Forest (The Beginner's Forest)",
+                'parent' => 'trabia-winter-island',
+                'notes' => 'This area is located right next to Shumi Village.',
+            ],
+            [
+                'name' => 'Chocobo Forest (The Basics Forest)',
+                'parent' => 'trabia-sorbald-snowfield',
+                'notes' => 'This area is located just South of Shumi Village.',
+            ],
+            [
+                'name' => 'Chocobo Forest (The Roaming Forest)',
+                'parent' => 'trabia-bika-snowfield',
+                'notes' => 'This area is located just North of Trabia Garden.',
+            ],
+        ];
+
+        $centraRegionLocations = [
+            // Overworld Areas.
+            [
+                'name' => 'Centra - Almaj Mountains',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Cape of Good Hope',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Centra Crater',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Lenown Plains',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Lolestern Plains',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Nectar Peninsula',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Poccarahi island',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Serengetti Plains',
+                'parent' => 'centra-region',
+            ],
+            [
+                'name' => 'Centra - Yorn Mountains',
+                'parent' => 'centra-region',
+            ],
+            // Overworld Locations.
+            [
+                'name' => 'Centra Ruins',
+                'parent' => 'centra-centra-crater',
+            ],
+            [
+                'name' => "Edea's House",
+                'parent' => 'centra-cape-of-good-hope',
+            ],
+            [
+                'name' => "Edea's House",
+                'slug' => "Edea's House (1)",
+                'parent' => 'centra-cape-of-good-hope',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => "Edea's House",
+                'slug' => "Edea's House (2)",
+                'parent' => 'edeas-house-1',
+            ],
+            [
+                'name' => "Edea's House - Bedroom",
+                'parent' => 'edeas-house-1',
+            ],
+            [
+                'name' => "Edea's House - Backyard",
+                'parent' => 'edeas-house-1',
+            ],
+            [
+                'name' => "Edea's House - Playroom",
+                'parent' => 'edeas-house-1',
+            ],
+            [
+                'name' => "Edea's House - Oceanside",
+                'parent' => 'edeas-house-1',
+            ],
+            [
+                'name' => "Edea's House - Flower Field",
+                'parent' => 'edeas-house-1',
+            ],
+            // Special Areas.
+            [
+                'name' => 'Centra - Excavation Site',
+                'parent' => 'centra-region',
+                'notes' => 'This are is only available during the Laguna dream sequence.',
+            ],
+            [
+                'name' => 'White SeeD Ship',
+                'slug' => 'White SeeD Ship (1)',
+                'parent' => 'centra-region',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'White SeeD Ship',
+                'slug' => 'White SeeD Ship (2)',
+                'parent' => 'white-seed-ship-1',
+            ],
+            [
+                'name' => 'White SeeD Ship - Cabin',
+                'parent' => 'white-seed-ship-1',
+            ],
+            [
+                'name' => 'Chocobo Forest (The Forest of Solitude)',
+                'parent' => 'centra-nectar-peninsula',
+                'notes' => 'This area is located on the Northeastern side of the Centra continent, on Nectar Peninsula.',
+            ],
+            [
+                'name' => 'Chocobo Forest (The Forest of Fun)',
+                'parent' => 'centra-lenown-plains',
+                'notes' => "This area is located right next to Edea's House.",
+            ],
+        ];
+
+        $estharRegionLocations = [
+            //Overworld Areas.
+            [
+                'name' => 'Esthar - Abadan Plains',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Cactuar Island',
+                'parent' => 'esthar-region',
+                'notes' => 'This area is located to the Southeast of Esthar and requires the Ragnarok. However, there is a bug in the game that will allow the player to encounter Cactuars if they run along the edge of the continent directly to the West of the island, which is accessible as soon as the player controls Balamb Garden.',
+            ],
+            [
+                'name' => 'Esthar - Fulcura Archipelago',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Grandidi forest',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Great Salt Lake',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Kashkabald Desert',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Millefeuille Archipelago',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Minde Island',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Mordred Plains',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Nortes Mountains',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Shalmal Peninsula',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Sollet mountains',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - Talle Mountains',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar - West Coast',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Esthar City',
+                'slug' => 'Esthar City (1)',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Great Plains of Esthar',
+                'parent' => 'esthar-region',
+            ],
+            [
+                'name' => 'Island Closest to Heaven',
+                'parent' => 'esthar-region',
+            ],
+            // Overworld Locations.
+            [
+                'name' => 'Great Salt Lake',
+                'slug' => 'Great Salt Lake (1)',
+                'parent' => 'esthar-great-salt-lake',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Great Salt Lake',
+                'parent' => 'great-salt-lake-1',
+            ],
+            [
+                'name' => 'Mystery Building',
+                'parent' => 'great-salt-lake-1',
+            ],
+            [
+                'name' => "Tears' Point",
+                'parent' => 'great-plains-of-esthar',
+            ],
+            [
+                'name' => 'Lunatic Pandora Laboratory',
+                'parent' => 'great-plains-of-esthar',
+            ],
+            [
+                'name' => 'Esthar Sorceress Memorial',
+                'slug' => 'Esthar Sorceress Memorial (1)',
+                'parent' => 'great-plains-of-esthar',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Esthar Sorceress Memorial',
+                'slug' => 'Esthar Sorceress Memorial (2)',
+                'parent' => 'esthar-sorceress-memorial-1',
+            ],
+            [
+                'name' => 'Sorceress Memorial - Entrance',
+                'parent' => 'esthar-sorceress-memorial-1',
+            ],
+            [
+                'name' => 'Sorceress Memorial - Hall',
+                'parent' => 'esthar-sorceress-memorial-1',
+            ],
+            [
+                'name' => 'Sorceress Memorial - Pod',
+                'parent' => 'esthar-sorceress-memorial-1',
+            ],
+            [
+                'name' => 'Sorceress Memorial - Ctrl Room',
+                'parent' => 'esthar-sorceress-memorial-1',
+            ],
+            [
+                'name' => 'Lunar Base',
+                'slug' => 'Lunar Base (1)',
+                'parent' => 'great-plains-of-esthar',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Lunar Base',
+                'slug' => 'Lunar Base (2)',
+                'parent' => 'lunar-base-1',
+            ],
+            [
+                'name' => 'Lunar Base - Concourse',
+                'parent' => 'lunar-base-1',
+            ],
+            [
+                'name' => 'Lunar Base - Deep Freeze',
+                'parent' => 'lunar-base-1',
+            ],
+            [
+                'name' => 'Lunatic Pandora',
+                'parent' => 'great-plains-of-esthar',
+            ],
+            [
+                'name' => 'Commencement Room',
+                'parent' => 'lunatic-pandora',
+                'notes' => 'This area is only accessible on disc 4, and is the location that the party finds themselves during time compression.',
+            ],
+            // Towns.
+            [
+                'name' => 'Esthar City',
+                'slug' => 'Esthar City (2)',
+                'parent' => 'esthar-city-1',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Esthar - City',
+                'slug' => 'Esthar City (3)',
+                'parent' => 'esthar-city-2',
+            ],
+            [
+                'name' => 'Esthar - Airstation',
+                'parent' => 'esthar-city-2',
+            ],
+            [
+                'name' => 'Presidential Palace',
+                'parent' => 'esthar-city-2',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Presidential Palace - Hall',
+                'parent' => 'presidential-palace',
+            ],
+            [
+                'name' => 'Presidential Palace - Hallway',
+                'parent' => 'presidential-palace',
+            ],
+            [
+                'name' => 'Presidential Palace - Office',
+                'parent' => 'presidential-palace',
+            ],
+            [
+                'name' => "Dr. Odine's Laboratory",
+                'parent' => 'esthar-city-2',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => "Esthar - Odine's Laboratory",
+                'parent' => 'dr-odines-laboratory',
+            ],
+            [
+                'name' => "Dr. Odine's Laboratory - Lobby",
+                'parent' => 'dr-odines-laboratory',
+            ],
+            [
+                'name' => "Dr. Odine's Laboratory - Lab",
+                'parent' => 'dr-odines-laboratory',
+            ],
+            // Special Areas.
+            [
+                'name' => 'Spaceship Landing Zone',
+                'parent' => 'esthar-kashkabald-desert',
+                'notes' => 'This is where Rinoa is taken from the Ragnarok upon returning from space.',
+            ],
+            [
+                'name' => 'Emergency Landing Zone',
+                'parent' => 'esthar-abadan-plains',
+                'notes' => "This area is where Piet is located after the events in space. It is labeled as 'Esthar - Abadan Plains' in the game menu.",
+            ],
+            [
+                'name' => 'Lunar Base',
+                'parent' => 'esthar-region',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Lunar Base - Control Room',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Lunar Base - Medical Room',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Lunar Base - Pod',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Lunar Base - Dock',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Lunar Base - Passageway',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Lunar Base - Locker',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Lunar Base - Residential Zone',
+                'parent' => 'lunar-base',
+            ],
+            [
+                'name' => 'Chocobo Forest (The Enclosed Forest)',
+                'parent' => 'esthar-talle-mountains',
+                'notes' => 'This area is located on the Southeastern tip of the Esthar continent, just East of the Centra continent.',
+            ],
+            [
+                'name' => 'Chocobo Forest (The Chocobo Sanctuary)',
+                'parent' => 'esthar-grandidi-forest',
+                'notes' => 'This area is located within the lower section of Grandidi Forest. In order to reach this location, the player must catch all 6 chocobos from the other forests. Once this has been completed, they must return to the Roaming Forest in Bika Snowfield on the Trabia continent to catch a chocobo and make their way to this one.',
+            ],
+        ];
+
+        $wildernessRegionLocations = [
+            // Special Locations.
+            [
+                'name' => 'Wilderness',
+                'parent' => 'wilderness-region',
+                'notes' => "This is the rea outside of Ultimecia's Castle",
+            ],
+            [
+                'name' => "Ultimecia's Castle",
+                'parent' => 'wilderness-region',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Ultimecia Castle',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Hall',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Grand Hall',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Terrace',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Wine Cellar',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Passageway',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Elevator Hall',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Stairway Hall',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Treasure Rm',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Storage Room',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Art Gallery',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Flood Gate',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Armory',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Prison Cell',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Waterway',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Courtyard',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Chapel',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Clock Tower',
+                'parent' => 'ultimecias-castle',
+            ],
+            [
+                'name' => 'Ultimecia Castle - Master Room',
+                'parent' => 'ultimecias-castle',
+            ],
+        ];
+
+        $noneRegionLocations = [
+            // Special Locations.
+            [
+                'name' => 'Ragnarok',
+                'parent' => 'none',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Ragnarok - Entrance',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Ragnarok - Aisle',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Ragnarok - Passenger Seat',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Ragnarok - Cockpit',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Ragnarok - Hangar',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Ragnarok - Air Room',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Ragnarok - Space Hatch',
+                'parent' => 'ragnarok',
+            ],
+            [
+                'name' => 'Deep Sea Research Center',
+                'slug' => 'Deep Sea Research Center (1)',
+                'parent' => 'none',
+                'notes' => 'This is not an in-game location. It is used as a container for a subset of child locations.',
+            ],
+            [
+                'name' => 'Deep Sea Research Center',
+                'slug' => 'Deep Sea Research Center (2)',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Research Center - Lb',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Research Center - Lv (1)',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Research Center - Lv (2)',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Research Center - Lv (3)',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Research Center - Lv (4)',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Research Center - Lv (5)',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+            [
+                'name' => 'Deep Sea Deposit',
+                'parent' => 'deep-sea-research-center-1',
+            ],
+        ];
+
+        // Loop through all of the regions first so that we can
+        // make sure they are always sorted at the top of the list.
+        $sortId = 1;
+        foreach ($regions as $regionKey => $region) {
+            $regions[$regionKey]['id'] = Uuid::generate(4);
+            $regions[$regionKey]['region_id'] = null;
+            $regions[$regionKey]['parent_id'] = null;
+            $regions[$regionKey]['sort_id'] = $sortId;
+            $regions[$regionKey]['slug'] = Str::slug($region['name']);
+            $regions[$regionKey]['notes'] = 'This is not an in-game location. It is used as a container for a subset of child locations.';
+            $regions[$regionKey]['created_at'] = Carbon::now();
+            $regions[$regionKey]['updated_at'] = Carbon::now();
+            $sortId++;
+        }
+
+        // Next, set up all of the data required for each area as it is associated with each region.
+        // We're using "variable variables" here to make things easier to digest within loops.
+        foreach ($regions as $region) {
+            $regionKey = explode('-', $region['slug'])[0];
+            $regionRecord = "{$regionKey}Region";
+            $regionLocations = "{$regionKey}RegionLocations";
+
+            ${$regionRecord} = $this->getLocationBySlug("{$regionKey}-region", $regions) ?: $this->getLocationBySlug("{$regionKey}", $regions);
+            foreach (${$regionLocations} as $locationKey => $area) {
+                $parentId = null;
+                if (array_key_exists('parent', $area)) {
+                    $parentLocation = $area['parent'] === ${$regionRecord}['slug']
+                        ? ${$regionRecord}
+                        : $this->getLocationBySlug($area['parent'], ${$regionLocations});
+
+                    $parentId = $parentLocation['id'];
+                    unset(${$regionLocations}[$locationKey]['parent']);
+                }
+
+                $slug = array_key_exists('slug', $area) ? Str::slug($area['slug']) : Str::slug($area['name']);
+                $notes = array_key_exists('notes', $area) ? $area['notes'] : null;
+
+                ${$regionLocations}[$locationKey]['id'] = Uuid::generate(4);
+                ${$regionLocations}[$locationKey]['region_id'] = ${$regionRecord}['id'];
+                ${$regionLocations}[$locationKey]['parent_id'] = $parentId;
+                ${$regionLocations}[$locationKey]['sort_id'] = $sortId;
+                ${$regionLocations}[$locationKey]['slug'] = $slug;
+                ${$regionLocations}[$locationKey]['notes'] = $notes;
+                ${$regionLocations}[$locationKey]['created_at'] = Carbon::now();
+                ${$regionLocations}[$locationKey]['updated_at'] = Carbon::now();
+                $sortId++;
+            }
+        }
+
+        // Insert the records in bulk.
+        $location = new Location();
+        $location->insert($regions);
+        foreach ($regions as $region) {
+            $regionKey = explode('-', $region['slug'])[0];
+            $regionLocations = "{$regionKey}RegionLocations";
+            $location->insert(${$regionLocations});
+        }
+    }
+
+    /**
+     * Find a location array using a given slug.
+     *
+     * @param string                           $slug      The slug to search for
+     * @param array<int, array<string, mixed>> $locations The locations to search through
+     *
+     * @return array<string, mixed>
+     */
+    protected function getLocationBySlug(string $slug, array $locations): array
+    {
+        $key = array_search($slug, array_column($locations, 'slug'));
+
+        return $key === false ? [] : $locations[$key];
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\V0\ElementController;
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\ItemController;
+use App\Http\Controllers\V0\LocationController;
 use App\Http\Controllers\V0\SearchController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
@@ -35,4 +36,7 @@ Route::group(['middleware' => 'relations.sanitize'], function () {
 
     Route::get('/items/')->uses([ItemController::class, 'index']);
     Route::get('/items/{id}')->uses([ItemController::class, 'show']);
+
+    Route::get('/locations/')->uses([LocationController::class, 'index']);
+    Route::get('/locations/{id}')->uses([LocationController::class, 'show']);
 });

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -75,6 +75,19 @@ class HealthCheckEndpointTest extends TestCase
                         'url' => "{$baseUrl}/v{$currentApiVersion}/items",
                         'query_parameters' => [],
                     ],
+                    'locations' => [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/locations",
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => [
+                                    'region',
+                                    'parent',
+                                    'locations',
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ]);

--- a/tests/Feature/Endpoints/V0/LocationEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/LocationEndpointTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Http\Transformers\V0\LocationTransformer;
+use App\Models\Location;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocationEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_locations(): void
+    {
+        Location::factory()->count(10)->create();
+
+        $response = $this->get('/v0/locations');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_location_using_the_id_key(): void
+    {
+        $location = Location::factory()->create()->toArray();
+
+        $response = $this->get("/v0/locations/{$location['id']}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $location['id'],
+                'region_id' => $location['region_id'],
+                'parent_id' => $location['parent_id'],
+                'sort_id' => $location['sort_id'],
+                'slug' => $location['slug'],
+                'name' => $location['name'],
+                'notes' => $location['notes'],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_return_an_individual_location_using_the_slug_key(): void
+    {
+        $location = Location::factory()->create()->toArray();
+
+        $response = $this->get("/v0/locations/{$location['slug']}");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $location['id'],
+                'region_id' => $location['region_id'],
+                'parent_id' => $location['parent_id'],
+                'sort_id' => $location['sort_id'],
+                'slug' => $location['slug'],
+                'name' => $location['name'],
+                'notes' => $location['notes'],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
+    {
+        $response = $this->get('/v0/locations/invalid');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_region_relation_on_a_list_of_locations(): void
+    {
+        Location::factory()
+            ->count(10)
+            ->for(Location::factory(), 'region')
+            ->create();
+
+        $response = $this->get('/v0/locations?include=region');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'region' => [
+                        // An array of Region Location data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        // This count will be skewed compared to others since it is a same-resource relation.
+        // 10 + 1 = 11
+        $response->assertJsonCount(11, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_region_relation_on_an_individual_location(): void
+    {
+        $location = Location::factory()
+            ->for(Location::factory(), 'region')
+            ->create()
+            ->load('region')
+            ->toArray();
+
+        $locationTransformer = $this->app->make(LocationTransformer::class);
+        $response = $this->get("/v0/locations/{$location['id']}?include=region");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $location['id'],
+                'region_id' => $location['region_id'],
+                'parent_id' => $location['parent_id'],
+                'sort_id' => $location['sort_id'],
+                'slug' => $location['slug'],
+                'name' => $location['name'],
+                'notes' => $location['notes'],
+                'region' => $locationTransformer->transformRecord($location['region']),
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_parent_relation_on_a_list_of_locations(): void
+    {
+        Location::factory()
+            ->count(10)
+            ->for(Location::factory(), 'parent')
+            ->create();
+
+        $response = $this->get('/v0/locations?include=parent');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'parent' => [
+                        // An array of Parent Location data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        // This count will be skewed compared to others since it is a same-resource relation.
+        // 10 + 1 = 11
+        $response->assertJsonCount(11, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_parent_relation_on_an_individual_location(): void
+    {
+        $location = Location::factory()
+            ->for(Location::factory(), 'parent')
+            ->create()
+            ->load('parent')
+            ->toArray();
+
+        $locationTransformer = $this->app->make(LocationTransformer::class);
+        $response = $this->get("/v0/locations/{$location['id']}?include=parent");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $location['id'],
+                'region_id' => $location['region_id'],
+                'parent_id' => $location['parent_id'],
+                'sort_id' => $location['sort_id'],
+                'slug' => $location['slug'],
+                'name' => $location['name'],
+                'notes' => $location['notes'],
+                'parent' => $locationTransformer->transformRecord($location['parent']),
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_locations_relation_on_a_list_of_locations(): void
+    {
+        Location::factory()
+            ->count(10)
+            ->has(Location::factory()->count(10))
+            ->create();
+
+        $response = $this->get('/v0/locations?include=locations');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'locations' => [
+                        // An array of Locations on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        // This count will be skewed compared to others since it is a same-resource relation.
+        // (10 * 10) + 10 = 110
+        $response->assertJsonCount(110, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_locations_relation_on_an_individual_location(): void
+    {
+        $location = Location::factory()
+            ->has(Location::factory()->count(10))
+            ->create()
+            ->load('locations')
+            ->toArray();
+
+        $locationTransformer = $this->app->make(LocationTransformer::class);
+        $response = $this->get("/v0/locations/{$location['id']}?include=locations");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $location['id'],
+                'region_id' => $location['region_id'],
+                'parent_id' => $location['parent_id'],
+                'sort_id' => $location['sort_id'],
+                'slug' => $location['slug'],
+                'name' => $location['name'],
+                'notes' => $location['notes'],
+                'locations' => $locationTransformer->transformCollection($location['locations']),
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Endpoints/V0/SearchEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SearchEndpointTest.php
@@ -2,7 +2,12 @@
 
 namespace Tests\Feature\Endpoints\V0;
 
+use App\Models\Element;
+use App\Models\Item;
+use App\Models\Location;
 use App\Models\SeedRank;
+use App\Models\SeedTest;
+use App\Models\StatusEffect;
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -101,5 +106,187 @@ class SearchEndpointTest extends TestCase
             'status_code' => 200,
         ]);
         $response->assertJsonCount(2, 'data.seed_ranks');
+    }
+
+    /** @test */
+    public function it_will_search_for_items(): void
+    {
+        Item::factory()->create([
+            'name' => 'Potion',
+        ]);
+
+        $response = $this->get('/v0/search?q=potion');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'items' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.items');
+    }
+
+    /** @test */
+    public function it_will_search_for_locations(): void
+    {
+        Location::factory()->create([
+            'name' => 'Balamb - Alcauld Plains',
+        ]);
+
+        $response = $this->get('/v0/search?q=Balamb');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'locations' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.locations');
+    }
+
+    /** @test */
+    public function it_will_search_for_seed_tests(): void
+    {
+        SeedTest::factory()->create([
+            'level' => 30,
+        ]);
+
+        $response = $this->get('/v0/search?q=30');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'seed_tests' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.seed_tests');
+    }
+
+    /** @test */
+    public function it_will_search_for_test_questions(): void
+    {
+        TestQuestion::factory()->create([
+            'question' => 'The Draw command extracts magic from enemies.',
+        ]);
+
+        $response = $this->get('/v0/search?q=draw');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'test_questions' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.test_questions');
+    }
+
+    /** @test */
+    public function it_will_search_for_status_effects(): void
+    {
+        StatusEffect::factory()->create([
+            'name' => 'Poison',
+        ]);
+
+        $response = $this->get('/v0/search?q=poison');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'status_effects' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.status_effects');
+    }
+
+    /** @test */
+    public function it_will_search_for_elements(): void
+    {
+        Element::factory()->create([
+            'name' => 'Fire',
+        ]);
+
+        $response = $this->get('/v0/search?q=fire');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'elements' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.elements');
+    }
+
+    /** @test */
+    public function it_will_search_for_seed_ranks(): void
+    {
+        SeedRank::factory()->create([
+            'salary' => 30000,
+        ]);
+
+        $response = $this->get('/v0/search?q=30000');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                'seed_ranks' => [],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(1, 'data.seed_ranks');
     }
 }

--- a/tests/Unit/Models/LocationTest.php
+++ b/tests/Unit/Models/LocationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Location;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_uses_the_proper_database_table(): void
+    {
+        $location = new Location();
+
+        $this->assertEquals('locations', $location->getTable());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_column_that_results_should_use_for_ordering(): void
+    {
+        $location = new Location();
+
+        $this->assertEquals('sort_id', $location->getOrderByField());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_visible_fields_for_api_consumption(): void
+    {
+        $location = new Location();
+
+        $visibleFields = [
+            'id',
+            'region_id',
+            'parent_id',
+            'sort_id',
+            'slug',
+            'name',
+            'notes',
+            'region',
+            'parent',
+            'locations',
+        ];
+
+        $this->assertEquals($visibleFields, $location->getVisible());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_cast_type_for_each_field(): void
+    {
+        $location = new Location();
+
+        $expected = [
+            'id' => 'string',
+            'region_id' => 'string',
+            'parent_id' => 'string',
+            'sort_id' => 'integer',
+            'slug' => 'string',
+            'name' => 'string',
+            'notes' => 'string',
+        ];
+
+        $this->assertEquals($expected, $location->getCasts());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_fields_that_are_searchable(): void
+    {
+        $location = new Location();
+
+        $expected = [
+            'slug',
+            'name',
+            'notes',
+        ];
+
+        $this->assertEquals($expected, $location->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource(): void
+    {
+        $location = new Location();
+
+        $expected = [
+            'region',
+            'parent',
+            'locations',
+        ];
+
+        $this->assertEquals($expected, $location->getAvailableIncludes());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource(): void
+    {
+        $location = new Location();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $location->getDefaultIncludes());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_route_key_name(): void
+    {
+        $location = new Location();
+
+        $this->assertEquals('slug', $location->getRouteKeyName());
+    }
+}

--- a/tests/Unit/Transformers/V0/LocationTransformerTest.php
+++ b/tests/Unit/Transformers/V0/LocationTransformerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Unit\Transformers\V0;
+
+use App\Http\Transformers\V0\LocationTransformer;
+use App\Models\Location;
+use Tests\TestCase;
+
+class LocationTransformerTest extends TestCase
+{
+    /** @test */
+    public function it_will_transform_a_single_record(): void
+    {
+        $location = Location::factory()->make([
+            'id' => 'some-random-uuid',
+            'region_id' => 'some-random-region-uuid',
+            'parent_id' => 'some-random-parent-uuid',
+            'sort_id' => 1,
+            'slug' => 'balamb-alcauld-plains',
+            'name' => 'Balamb - Alcauld Plains',
+            'notes' => null,
+        ])->toArray();
+
+        $transformer = new LocationTransformer();
+
+        $transformedRecord = $transformer->transformRecord($location);
+
+        $this->assertEquals([
+            'id' => $location['id'],
+            'region_id' => $location['region_id'],
+            'parent_id' => $location['parent_id'],
+            'sort_id' => $location['sort_id'],
+            'slug' => $location['slug'],
+            'name' => $location['name'],
+            'notes' => $location['notes'],
+        ], $transformedRecord);
+    }
+
+    /** @test */
+    public function it_will_transform_a_collection_of_records(): void
+    {
+        $locations = Location::factory()->count(3)->sequence(
+            ['id' => 'one'],
+            ['id' => 'two'],
+            ['id' => 'three']
+        )->make()->toArray();
+
+        $transformer = new LocationTransformer();
+
+        $transformedRecords = $transformer->transformCollection($locations);
+
+        $this->assertEquals([
+            [
+                'id' => $locations[0]['id'],
+                'region_id' => $locations[0]['region_id'],
+                'parent_id' => $locations[0]['parent_id'],
+                'sort_id' => $locations[0]['sort_id'],
+                'slug' => $locations[0]['slug'],
+                'name' => $locations[0]['name'],
+                'notes' => $locations[0]['notes'],
+            ],
+            [
+                'id' => $locations[1]['id'],
+                'region_id' => $locations[1]['region_id'],
+                'parent_id' => $locations[1]['parent_id'],
+                'sort_id' => $locations[1]['sort_id'],
+                'slug' => $locations[1]['slug'],
+                'name' => $locations[1]['name'],
+                'notes' => $locations[1]['notes'],
+            ],
+            [
+                'id' => $locations[2]['id'],
+                'region_id' => $locations[2]['region_id'],
+                'parent_id' => $locations[2]['parent_id'],
+                'sort_id' => $locations[2]['sort_id'],
+                'slug' => $locations[2]['slug'],
+                'name' => $locations[2]['name'],
+                'notes' => $locations[2]['notes'],
+            ],
+        ], $transformedRecords);
+    }
+
+    /** @test */
+    public function it_will_transform_the_region_record_if_it_is_present(): void
+    {
+        $region = Location::factory()->make([
+            'id' => 'some-random-region-uuid',
+            'region_id' => null,
+            'parent_id' => null,
+            'sort_id' => 1,
+            'slug' => 'balamb-region',
+            'name' => 'Balamb (Region)',
+            'notes' => null,
+        ])->toArray();
+
+        $location = Location::factory()->make([
+            'id' => 'some-random-uuid',
+            'region_id' => 'some-random-region-uuid',
+            'parent_id' => 'some-random-region-uuid', // Region is also the parent here.
+            'sort_id' => 1,
+            'slug' => 'balamb-alcauld-plains',
+            'name' => 'Balamb - Alcauld Plains',
+            'notes' => null,
+        ])->toArray();
+
+        // Manually append the Region to the record since we're not using the database.
+        $location['region'] = $region;
+
+        $transformer = new LocationTransformer();
+
+        $transformedRegion = $transformer->transformRecord($region);
+        $transformedLocation = $transformer->transformRecord($location);
+
+        $this->assertEquals($transformedRegion, $transformedLocation['region']);
+    }
+
+    /** @test */
+    public function it_will_transform_the_parent_record_if_it_is_present(): void
+    {
+        $parent = Location::factory()->make([
+            'id' => 'some-random-region-uuid',
+            'region_id' => null,
+            'parent_id' => null,
+            'sort_id' => 1,
+            'slug' => 'balamb-region',
+            'name' => 'Balamb (Region)',
+            'notes' => null,
+        ])->toArray();
+
+        $location = Location::factory()->make([
+            'id' => 'some-random-uuid',
+            'region_id' => 'some-random-region-uuid',
+            'parent_id' => 'some-random-region-uuid', // Region is also the parent here.
+            'sort_id' => 1,
+            'slug' => 'balamb-alcauld-plains',
+            'name' => 'Balamb - Alcauld Plains',
+            'notes' => null,
+        ])->toArray();
+
+        // Manually append the Parent to the record since we're not using the database.
+        $location['parent'] = $parent;
+
+        $transformer = new LocationTransformer();
+
+        $transformedParent = $transformer->transformRecord($parent);
+        $transformedLocation = $transformer->transformRecord($location);
+
+        $this->assertEquals($transformedParent, $transformedLocation['parent']);
+    }
+
+    /** @test */
+    public function it_will_transform_the_child_records_if_they_are_present(): void
+    {
+        $region = Location::factory()->make([
+            'id' => 'some-random-region-uuid',
+            'region_id' => null,
+            'parent_id' => null,
+            'sort_id' => 1,
+            'slug' => 'balamb-region',
+            'name' => 'Balamb (Region)',
+            'notes' => null,
+        ])->toArray();
+
+        $location = Location::factory()->make([
+            'id' => 'some-random-uuid',
+            'region_id' => 'some-random-region-uuid',
+            'parent_id' => 'some-random-region-uuid', // Region is also the parent here.
+            'sort_id' => 1,
+            'slug' => 'balamb-alcauld-plains',
+            'name' => 'Balamb - Alcauld Plains',
+            'notes' => null,
+        ])->toArray();
+
+        // Manually append the child Location to the record since we're not using the database.
+        $region['locations'] = [$location];
+
+        $transformer = new LocationTransformer();
+
+        $transformedRegion = $transformer->transformRecord($region);
+        $transformedLocation = $transformer->transformRecord($location);
+
+        $this->assertEquals([$transformedLocation], $transformedRegion['locations']);
+    }
+}


### PR DESCRIPTION
Pretty large addition this time. With the Locations resource comes the building blocks for future additions. Draw Points, Enemies, Items, Cards, Guardian Forces, etc... All of these will rely upon the Location resource, so extra time was taken to make sure that the structure will work with the coming additions to the system.

The Locations resource utilizes a same-table relationship on itself to handle child/parent areas. That is to say, a Location can both belong to another area, and also have child areas that belong to it. For example; there are 11 different regions throughout the game. Each of these regions contain a subset of overworld areas, of which also contain various other areas such as towns. While they are all still considered locations in the game, they have a set hierarchy in place to help identify where they exist within the game world. This was taken into consideration when designing the relationship structure for the resource.

To get the different relationships between these records, the `region`, `parent` and `locations` methods may be used to return what you would expect them to return. The `region` method will return the current region that a record belongs to. All records will have a region tied to them, whether or not they are nested within the hierarchy. They *are* still associated with a specific region after all regardless of whether the area is in a town or a dungeon. The `parent` method will return the area directly above the current record. If the area is a hotel in a town, then it would be the town that is returned. The `locations` method will return the direct descendants associated with the current record. If the current record in question is a town, it will return the locations present within said town.

Due to this relationship hierarchy and the way that the game was designed, it was necessary to introduce "placeholder" or "container" locations to group some of these locations together. This is an area that doesn't technically exist within the game, but is understood to be within the game world. For example, Balamb Town doesn't have an area named "Balamb Town". Instead, the main area of the town is listed as "Balamb - Town Square". It made more sense to create a "container" record with the name "Balamb Town" and then tie the areas related to Balamb Town to this record instead of "Balamb - Town Square". These records are outlined within the notes section of each applicable record.

All of these records have also been added to the search provide as well. The Locations resource has been placed second in the priority list as this is anticipated to be commonly searched for.