### PR TITLE
feat: include relational resources

### DIFF
--- a/app/Contracts/Services/ModelService.php
+++ b/app/Contracts/Services/ModelService.php
@@ -26,4 +26,15 @@ interface ModelService
      * @return array<string, mixed>
      */
     public function findOrFail(string $id, array $includes = []): array;
+
+    /**
+     * Retrieve the specified relation through the parent record, or fail if the parent record was not found.
+     *
+     * @param string             $id       The ID of the requested resource
+     * @param string             $relation The relation to load on the resource
+     * @param array<int, string> $includes The relations to include on the resource
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findRelationOrFail(string $id, string $relation, array $includes = []): array;
 }

--- a/app/Http/Controllers/RelationalResourceController.php
+++ b/app/Http/Controllers/RelationalResourceController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Contracts\Services\ModelService;
+use App\Contracts\Transformers\RecordTransformer;
+use App\Traits\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class RelationalResourceController extends Controller
+{
+    use ApiResponse;
+
+    /**
+     * Instance of the ModelService.
+     *
+     * @var ModelService
+     */
+    protected $service;
+
+    /**
+     * Instance of the RecordTransformer.
+     *
+     * @var RecordTransformer
+     */
+    protected $transformer;
+
+    /**
+     * The relation to load on the resource.
+     *
+     * @var string
+     */
+    protected $relation;
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request The HTTP request from the client
+     * @param string  $id      The ID of the requested record
+     *
+     * @return JsonResponse
+     */
+    public function index(Request $request, string $id): JsonResponse
+    {
+        $records = $this->service->findRelationOrFail(
+            $id,
+            $this->relation,
+            $request->get('include', [])
+        );
+
+        return $this->respondWithSuccess(
+            'Successfully retrieved data.',
+            $this->transformer->transformCollection($records)
+        );
+    }
+}

--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -24,65 +24,123 @@ class HealthCheckController extends Controller
             'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
             'resources' => [
                 'search' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/search",
-                    'query_parameters' => [
-                        'q' => [
-                            'description' => 'The search query.',
-                            'options' => [],
-                        ],
-                        'only' => [
-                            'description' => 'A comma separated list of resources to search. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                            'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
-                        ],
-                        'exclude' => [
-                            'description' => 'A comma separated list of resources to exclude from search results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                            'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/search",
+                        'url_parameters' => [],
+                        'query_parameters' => [
+                            'q' => [
+                                'description' => 'The search query.',
+                                'options' => [],
+                            ],
+                            'only' => [
+                                'description' => 'A comma separated list of resources to search. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
+                            ],
+                            'exclude' => [
+                                'description' => 'A comma separated list of resources to exclude from search results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
+                            ],
                         ],
                     ],
                 ],
                 'seed_ranks' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
-                    'query_parameters' => [],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+                        'url_parameters' => [],
+                        'query_parameters' => [],
+                    ],
                 ],
                 'seed_tests' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
-                    'query_parameters' => [
-                        'include' => [
-                            'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                            'options' => ['test-questions'],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
+                        'url_parameters' => [],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['test-questions'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests/{seed-test}/test-questions",
+                        'url_parameters' => [
+                            '{seed-test}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'level'],
+                            ],
+                        ],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['seed-test'],
+                            ],
                         ],
                     ],
                 ],
                 'test_questions' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
-                    'query_parameters' => [
-                        'include' => [
-                            'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                            'options' => ['seed-test'],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
+                        'url_parameters' => [],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['seed-test'],
+                            ],
                         ],
                     ],
                 ],
                 'status_effects' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
-                    'query_parameters' => [],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
+                        'url_parameters' => [],
+                        'query_parameters' => [],
+                    ],
                 ],
                 'elements' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/elements",
-                    'query_parameters' => [],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/elements",
+                        'url_parameters' => [],
+                        'query_parameters' => [],
+                    ],
                 ],
                 'items' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/items",
-                    'query_parameters' => [],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/items",
+                        'url_parameters' => [],
+                        'query_parameters' => [],
+                    ],
                 ],
                 'locations' => [
-                    'url' => "{$baseUrl}/v{$currentApiVersion}/locations",
-                    'query_parameters' => [
-                        'include' => [
-                            'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                            'options' => [
-                                'region',
-                                'parent',
-                                'locations',
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/locations",
+                        'url_parameters' => [],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => [
+                                    'region',
+                                    'parent',
+                                    'locations',
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/locations/{location}/locations",
+                        'url_parameters' => [
+                            '{location}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'slug'],
+                            ],
+                        ],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => [
+                                    'region',
+                                    'parent',
+                                    'locations',
+                                ],
                             ],
                         ],
                     ],

--- a/app/Http/Controllers/V0/LocationLocationController.php
+++ b/app/Http/Controllers/V0/LocationLocationController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\LocationService;
+use App\Http\Controllers\RelationalResourceController;
+use App\Http\Transformers\V0\LocationTransformer;
+
+class LocationLocationController extends RelationalResourceController
+{
+    /**
+     * Create a new SeedTestController instance.
+     *
+     * @param LocationService     $locationService     The Service that will process the request
+     * @param LocationTransformer $locationTransformer The Transformer that will standardize the response
+     */
+    public function __construct(LocationService $locationService, LocationTransformer $locationTransformer)
+    {
+        $this->service = $locationService;
+        $this->transformer = $locationTransformer;
+        $this->relation = 'locations';
+    }
+}

--- a/app/Http/Controllers/V0/SeedTestTestQuestionController.php
+++ b/app/Http/Controllers/V0/SeedTestTestQuestionController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\SeedTestService;
+use App\Http\Controllers\RelationalResourceController;
+use App\Http\Transformers\V0\TestQuestionTransformer;
+
+class SeedTestTestQuestionController extends RelationalResourceController
+{
+    /**
+     * Create a new SeedTestTestQuestionController instance.
+     *
+     * @param SeedTestService         $seedTestService         The Service that will process the request
+     * @param TestQuestionTransformer $testQuestionTransformer The Transformer that will standardize the response
+     */
+    public function __construct(SeedTestService $seedTestService, TestQuestionTransformer $testQuestionTransformer)
+    {
+        $this->service = $seedTestService;
+        $this->transformer = $testQuestionTransformer;
+        $this->relation = 'testQuestions';
+    }
+}

--- a/app/Services/ModelService.php
+++ b/app/Services/ModelService.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\Contracts\Services\ModelService as ModelServiceContract;
 use App\Models\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ModelService implements ModelServiceContract
@@ -25,7 +27,7 @@ class ModelService implements ModelServiceContract
      */
     public function all(array $includes = []): array
     {
-        $query = $this->getNewQueryBuilderInstance();
+        $query = $this->getNewQueryBuilderInstance($this->model);
 
         $results = $query->with(
             $this->model->verifyIncludes($includes)
@@ -62,12 +64,59 @@ class ModelService implements ModelServiceContract
     }
 
     /**
+     * Retrieve the specified relation through the parent record, or fail if the parent record was not found.
+     *
+     * @param string             $id       The ID of the requested resource
+     * @param string             $relation The relation to load on the resource
+     * @param array<int, string> $includes The relations to include on the resource
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function findRelationOrFail(string $id, string $relation, array $includes = []): array
+    {
+        $related = $this->getRelatedInstance($relation);
+
+        $data = $this->model
+            ->with(array_map(
+                // Bypass the depth limit by prefixing the requested includes.
+                fn ($item) => "{$relation}.{$item}",
+                $related->verifyIncludes($includes)
+            ))
+            ->where($this->model->getKeyName(), $id)
+            ->orWhere($this->model->getRouteKeyName(), $id)
+            ->first();
+
+        if (! $data) {
+            throw new NotFoundHttpException('The requested record could not be found.');
+        }
+
+        return $data->{$relation}->toArray();
+    }
+
+    /**
      * Create a new query builder instance.
+     *
+     * @param Model $model The model instance for which to create a new query builder
      *
      * @return Builder<Model>
      */
-    protected function getNewQueryBuilderInstance(): Builder
+    protected function getNewQueryBuilderInstance(Model $model): Builder
     {
-        return $this->model->newQuery();
+        return $model->newQuery();
+    }
+
+    /**
+     * Create a new instance of the related model.
+     *
+     * @param string $relation The name of the relation to instantiate
+     *
+     * @return Model<EloquentModel>
+     */
+    protected function getRelatedInstance(string $relation): Model
+    {
+        /** @var Relation */
+        $relation = $this->model->{$relation}();
+
+        return $relation->getRelated();
     }
 }

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -4,9 +4,11 @@ use App\Http\Controllers\V0\ElementController;
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\ItemController;
 use App\Http\Controllers\V0\LocationController;
+use App\Http\Controllers\V0\LocationLocationController;
 use App\Http\Controllers\V0\SearchController;
 use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
+use App\Http\Controllers\V0\SeedTestTestQuestionController;
 use App\Http\Controllers\V0\StatusEffectController;
 use App\Http\Controllers\V0\TestQuestionController;
 use Illuminate\Support\Facades\Route;
@@ -24,6 +26,7 @@ Route::group(['middleware' => 'relations.sanitize'], function () {
 
     Route::get('/seed-tests/')->uses([SeedTestController::class, 'index']);
     Route::get('/seed-tests/{test}')->uses([SeedTestController::class, 'show']);
+    Route::get('/seed-tests/{test}/test-questions')->uses([SeedTestTestQuestionController::class, 'index']);
 
     Route::get('/test-questions/')->uses([TestQuestionController::class, 'index']);
     Route::get('/test-questions/{id}')->uses([TestQuestionController::class, 'show']);
@@ -39,4 +42,5 @@ Route::group(['middleware' => 'relations.sanitize'], function () {
 
     Route::get('/locations/')->uses([LocationController::class, 'index']);
     Route::get('/locations/{id}')->uses([LocationController::class, 'show']);
+    Route::get('/locations/{id}/locations')->uses([LocationLocationController::class, 'index']);
 });

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -25,65 +25,123 @@ class HealthCheckEndpointTest extends TestCase
                 'message' => 'VIIIDB API is currently under construction and is subject to frequent major changes. The following resources are currently available for consumption.',
                 'resources' => [
                     'search' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/search",
-                        'query_parameters' => [
-                            'q' => [
-                                'description' => 'The search query.',
-                                'options' => [],
-                            ],
-                            'only' => [
-                                'description' => 'A comma separated list of resources to search. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                                'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
-                            ],
-                            'exclude' => [
-                                'description' => 'A comma separated list of resources to exclude from search results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                                'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/search",
+                            'url_parameters' => [],
+                            'query_parameters' => [
+                                'q' => [
+                                    'description' => 'The search query.',
+                                    'options' => [],
+                                ],
+                                'only' => [
+                                    'description' => 'A comma separated list of resources to search. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
+                                ],
+                                'exclude' => [
+                                    'description' => 'A comma separated list of resources to exclude from search results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['seed-ranks', 'seed-tests', 'test-questions', 'status-effects', 'elements'],
+                                ],
                             ],
                         ],
                     ],
                     'seed_ranks' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
-                        'query_parameters' => [],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks",
+                            'url_parameters' => [],
+                            'query_parameters' => [],
+                        ],
                     ],
                     'seed_tests' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
-                        'query_parameters' => [
-                            'include' => [
-                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                                'options' => ['test-questions'],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
+                            'url_parameters' => [],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['test-questions'],
+                                ],
+                            ],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests/{seed-test}/test-questions",
+                            'url_parameters' => [
+                                '{seed-test}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'level'],
+                                ],
+                            ],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['seed-test'],
+                                ],
                             ],
                         ],
                     ],
                     'test_questions' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
-                        'query_parameters' => [
-                            'include' => [
-                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                                'options' => ['seed-test'],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/test-questions",
+                            'url_parameters' => [],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['seed-test'],
+                                ],
                             ],
                         ],
                     ],
                     'status_effects' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
-                        'query_parameters' => [],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
+                            'url_parameters' => [],
+                            'query_parameters' => [],
+                        ],
                     ],
                     'elements' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/elements",
-                        'query_parameters' => [],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/elements",
+                            'url_parameters' => [],
+                            'query_parameters' => [],
+                        ],
                     ],
                     'items' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/items",
-                        'query_parameters' => [],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/items",
+                            'url_parameters' => [],
+                            'query_parameters' => [],
+                        ],
                     ],
                     'locations' => [
-                        'url' => "{$baseUrl}/v{$currentApiVersion}/locations",
-                        'query_parameters' => [
-                            'include' => [
-                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
-                                'options' => [
-                                    'region',
-                                    'parent',
-                                    'locations',
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/locations",
+                            'url_parameters' => [],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => [
+                                        'region',
+                                        'parent',
+                                        'locations',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/locations/{location}/locations",
+                            'url_parameters' => [
+                                '{location}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'slug'],
+                                ],
+                            ],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => [
+                                        'region',
+                                        'parent',
+                                        'locations',
+                                    ],
                                 ],
                             ],
                         ],

--- a/tests/Feature/Endpoints/V0/LocationLocationEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/LocationLocationEndpointTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\Location;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocationLocationEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_locations_related_to_a_location_using_the_id_key(): void
+    {
+        $location = Location::factory()
+            ->has(Location::factory()->count(10))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/locations/{$location['id']}/locations");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_a_list_of_locations_related_to_a_location_using_the_slug_key(): void
+    {
+        $location = Location::factory()
+            ->has(Location::factory()->count(10))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/locations/{$location['slug']}/locations");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
+    {
+        $response = $this->get('/v0/locations/invalid/locations');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_region_relation_on_a_list_of_locations(): void
+    {
+        $region = Location::factory();
+        $location = Location::factory()
+            ->has($region, 'region')
+            ->has(
+                Location::factory()->count(10)->has($region, 'region'),
+                'locations'
+            )
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/locations/{$location['id']}/locations?include=region");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'region' => [
+                        // An array of Region data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_parent_relation_on_a_list_of_locations(): void
+    {
+        $location = Location::factory()
+            ->create()
+            ->toArray();
+        Location::factory()->count(10)->create(['parent_id' => $location['id']]);
+
+        $response = $this->get("/v0/locations/{$location['id']}/locations?include=parent");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'parent' => [
+                        // An array of Parent data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_locations_relation_on_a_list_of_locations(): void
+    {
+        /**
+         * Triple nested relationship.
+         * Top level Location has 10 children.
+         * Each of those first level children, also have 10 children.
+         * The third level should be reflected within the results.
+         */
+        $location = Location::factory()
+            ->has(
+                Location::factory()->has(
+                    Location::factory()->count(10),
+                    'locations'
+                )->count(10),
+                'locations'
+            )
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/locations/{$location['id']}/locations?include=locations");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'locations' => [
+                        // An array of Location data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+}

--- a/tests/Feature/Endpoints/V0/SeedTestTestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestTestQuestionEndpointTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\SeedTest;
+use App\Models\TestQuestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeedTestTestQuestionEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_return_a_list_of_test_questions_related_to_a_seed_test_using_the_id_key(): void
+    {
+        $seedTest = SeedTest::factory()
+            ->has(TestQuestion::factory()->count(10))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/seed-tests/{$seedTest['id']}/test-questions");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_a_list_of_test_questions_related_to_a_seed_test_using_the_level_key(): void
+    {
+        $seedTest = SeedTest::factory()
+            ->has(TestQuestion::factory()->count(10))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/seed-tests/{$seedTest['level']}/test-questions");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_an_individual_record_is_not_found(): void
+    {
+        $response = $this->get('/v0/seed-tests/invalid/test-questions');
+
+        $response->assertStatus(404);
+        $response->assertExactJson([
+            'success' => false,
+            'message' => 'The requested record could not be found.',
+            'status_code' => 404,
+            'errors' => [
+                'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_seed_test_relation_on_a_list_of_test_questions(): void
+    {
+        $seedTest = SeedTest::factory()
+            ->has(TestQuestion::factory()->count(10))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/seed-tests/{$seedTest['id']}/test-questions?include=seed-test");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'seed_test' => [
+                        // An array of SeeD Test data on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+}


### PR DESCRIPTION
This introduces relational resources that are a maximum of one level deep. It is not possible to view the Test Questions that are associated with a SeeD Test, as well as Locations that have an associated parent Location. Simply request the desired child resource when hitting the API endpoints for a specific record.

* `/locations/{locationId}/locations`
* `/seed-tests/{seedTestId}/test-questions`