### PR TITLE
ci: include phpstan within ci pipeline

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -22,7 +22,10 @@ jobs:
       - name: Run Unit Tests
         run: |
           php artisan key:generate --env=testing
-          vendor/bin/phpunit
+          composer run test
+
+      - name: Run PHPStan
+        run: composer run phpstan
 
   # We only want to build the branch if the commit was not pushed as part of an automated release.
   # In the event the commit was pushed as part of the automated release, it would have already

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -20,7 +20,10 @@ jobs:
       - name: Run Unit Tests
         run: |
           php artisan key:generate --env=testing
-          vendor/bin/phpunit
+          composer run test
+
+      - name: Run PHPStan
+        run: composer run phpstan
 
   build-image:
     name: Build Docker Image

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,7 +21,10 @@ jobs:
       - name: Run Unit Tests
         run: |
           php artisan key:generate --env=testing
-          vendor/bin/phpunit
+          composer run test
+
+      - name: Run PHPStan
+        run: composer run phpstan
 
   # We want to release every commit that is pushed to master, with the exception of commits that are created
   # as part of a changelog update. Changelog updates do not need to be built. There are two reasons for this.

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,4 +18,7 @@ jobs:
       - name: Run Unit Tests
         run: |
           php artisan key:generate --env=testing
-          vendor/bin/phpunit
+          composer run test
+
+      - name: Run PHPStan
+        run: composer run phpstan

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,8 +5,5 @@ RUN apk add --no-cache \
   git \
   openssh
 
-# Increase the PHP memory limit for development.
-RUN echo $'\nmemory_limit = 1G' >> /etc/php/php.ini 
-
 # Let's make the terminal look nicer.
 RUN echo 'export PS1="┌─ 🐳 \[\e[0;1;30;43m\] \u \[\e[0m\]\[\e[0;1;30;46m\] \h \[\e[0m\]\[\e[0;1;30;47m\] \w \[\e[0m\] \n└─ $ "' >> /etc/profile


### PR DESCRIPTION
This simply includes PHPStan as part of the CI workflows. Nothing fancy to outline -- PHPStan will simply run after the unit tests when creating pull requests, and when building a branch/release.