### PR TITLE
feat: add rate limiting to api calls (API-82)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM defrostedtuna/php-nginx:8.1
 
+RUN apk add --no-cache \
+  php81-redis
+
 # Copy the project files.
 COPY . /app
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,7 +52,7 @@ class Kernel extends HttpKernel
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'search.sanitize' => \App\Http\Middleware\SanitizesSearchInput::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'request.capture' => \App\Http\Middleware\CaptureInboundRequest::class,
         'relations.sanitize' => \App\Http\Middleware\SanitizesRelationalIncludes::class,

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -2,6 +2,7 @@ FROM defrostedtuna/php-nginx:8.1-dev
 
 # Git and OpenSSH are needed for the Remote Containers setup.
 RUN apk add --no-cache \
+  php81-redis \
   git \
   openssh
 

--- a/tests/Feature/Endpoints/V0/ElementEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/ElementEndpointTest.php
@@ -4,11 +4,21 @@ namespace Tests\Feature\Endpoints\V0;
 
 use App\Models\Element;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class ElementEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_elements(): void

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -2,10 +2,20 @@
 
 namespace Tests\Feature\Endpoints\V0;
 
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class HealthCheckEndpointTest extends TestCase
 {
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
+
     /** @test */
     public function it_can_check_the_server_status(): void
     {

--- a/tests/Feature/Endpoints/V0/ItemEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/ItemEndpointTest.php
@@ -4,11 +4,21 @@ namespace Tests\Feature\Endpoints\V0;
 
 use App\Models\Item;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class ItemEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_items(): void

--- a/tests/Feature/Endpoints/V0/LocationEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/LocationEndpointTest.php
@@ -5,11 +5,21 @@ namespace Tests\Feature\Endpoints\V0;
 use App\Http\Transformers\V0\LocationTransformer;
 use App\Models\Location;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class LocationEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_locations(): void

--- a/tests/Feature/Endpoints/V0/LocationLocationEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/LocationLocationEndpointTest.php
@@ -4,11 +4,21 @@ namespace Tests\Feature\Endpoints\V0;
 
 use App\Models\Location;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class LocationLocationEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_locations_related_to_a_location_using_the_id_key(): void

--- a/tests/Feature/Endpoints/V0/SearchEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SearchEndpointTest.php
@@ -10,11 +10,21 @@ use App\Models\SeedTest;
 use App\Models\StatusEffect;
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class SearchEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_search_for_records(): void

--- a/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
@@ -4,11 +4,21 @@ namespace Tests\Feature\Endpoints\V0;
 
 use App\Models\SeedRank;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class SeedRankEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_seed_ranks(): void

--- a/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
@@ -6,11 +6,21 @@ use App\Http\Transformers\V0\TestQuestionTransformer;
 use App\Models\SeedTest;
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class SeedTestEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_seed_tests(): void

--- a/tests/Feature/Endpoints/V0/SeedTestTestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestTestQuestionEndpointTest.php
@@ -5,11 +5,21 @@ namespace Tests\Feature\Endpoints\V0;
 use App\Models\SeedTest;
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class SeedTestTestQuestionEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_test_questions_related_to_a_seed_test_using_the_id_key(): void

--- a/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
@@ -4,11 +4,21 @@ namespace Tests\Feature\Endpoints\V0;
 
 use App\Models\StatusEffect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class StatusEffectEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_status_effects(): void

--- a/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
@@ -6,11 +6,21 @@ use App\Http\Transformers\V0\SeedTestTransformer;
 use App\Models\SeedTest;
 use App\Models\TestQuestion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Tests\TestCase;
 
 class TestQuestionEndpointTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [
+        ThrottleRequestsWithRedis::class,
+    ];
 
     /** @test */
     public function it_will_return_a_list_of_test_questions(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,4 +9,23 @@ abstract class TestCase extends BaseTestCase
 {
     use ArraySubsetAsserts;
     use CreatesApplication;
+
+    /**
+     * The middleware to exclude when running tests.
+     * 
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddlware = [];
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware($this->excludedMiddlware);
+    }
 }


### PR DESCRIPTION
This adds rate limiting support that will apply within a multi-container Kubernetes setup. Using Redis, we can store a central state between all of the deployed containers that will keep track of the IP address that a request comes from, along with the number of requests that said IP has sent over the course of the last 60 seconds. By default, this will allow 60 requests per minute for each IP.