### PR TITLE
feat: include relation between items and status effects (API-13)

### DIFF
--- a/app/Http/Controllers/V0/HealthCheckController.php
+++ b/app/Http/Controllers/V0/HealthCheckController.php
@@ -49,11 +49,36 @@ class HealthCheckController extends Controller
                         'url_parameters' => [],
                         'query_parameters' => [],
                     ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks/{seed-rank}",
+                        'url_parameters' => [
+                            '{seed-rank}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'rank'],
+                            ],
+                        ],
+                        'query_parameters' => [],
+                    ],
                 ],
                 'seed_tests' => [
                     [
                         'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
                         'url_parameters' => [],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['test-questions'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests/{seed-test}",
+                        'url_parameters' => [
+                            '{seed-test}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'level'],
+                            ],
+                        ],
                         'query_parameters' => [
                             'include' => [
                                 'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
@@ -88,12 +113,62 @@ class HealthCheckController extends Controller
                             ],
                         ],
                     ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/test-questions/{test-question}",
+                        'url_parameters' => [
+                            '{test-question}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id'],
+                            ],
+                        ],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['seed-test'],
+                            ],
+                        ],
+                    ],
                 ],
                 'status_effects' => [
                     [
                         'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
                         'url_parameters' => [],
-                        'query_parameters' => [],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['items'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects/{status-effect}",
+                        'url_parameters' => [
+                            '{status-effect}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'name'],
+                            ],
+                        ],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['items'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects/{status-effect}/items",
+                        'url_parameters' => [
+                            '{status-effect}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'name'],
+                            ],
+                        ],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['status-effects'],
+                            ],
+                        ],
                     ],
                 ],
                 'elements' => [
@@ -102,12 +177,47 @@ class HealthCheckController extends Controller
                         'url_parameters' => [],
                         'query_parameters' => [],
                     ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/elements/{element}",
+                        'url_parameters' => [
+                            '{element}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'name'],
+                            ],
+                        ],
+                        'query_parameters' => [],
+                    ],
                 ],
                 'items' => [
                     [
                         'url' => "{$baseUrl}/v{$currentApiVersion}/items",
                         'url_parameters' => [],
                         'query_parameters' => [],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/items/{item}",
+                        'url_parameters' => [
+                            '{item}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'slug'],
+                            ],
+                        ],
+                        'query_parameters' => [],
+                    ],
+                    [
+                        'url' => "{$baseUrl}/v{$currentApiVersion}/items/{item}/status-effects",
+                        'url_parameters' => [
+                            '{item}' => [
+                                'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                'options' => ['id', 'slug'],
+                            ],
+                        ],
+                        'query_parameters' => [
+                            'include' => [
+                                'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                'options' => ['items'],
+                            ],
+                        ],
                     ],
                 ],
                 'locations' => [

--- a/app/Http/Controllers/V0/ItemStatusEffectController.php
+++ b/app/Http/Controllers/V0/ItemStatusEffectController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\ItemService;
+use App\Http\Controllers\RelationalResourceController;
+use App\Http\Transformers\V0\StatusEffectTransformer;
+
+class ItemStatusEffectController extends RelationalResourceController
+{
+    /**
+     * Create a new ItemStatusEffectController instance.
+     *
+     * @param ItemService             $itemService             The Service that will process the request
+     * @param StatusEffectTransformer $statusEffectTransformer The Transformer that will standardize the response
+     */
+    public function __construct(ItemService $itemService, StatusEffectTransformer $statusEffectTransformer)
+    {
+        $this->service = $itemService;
+        $this->transformer = $statusEffectTransformer;
+        $this->relation = 'statusEffects';
+    }
+}

--- a/app/Http/Controllers/V0/StatusEffectItemController.php
+++ b/app/Http/Controllers/V0/StatusEffectItemController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\V0;
+
+use App\Contracts\Services\StatusEffectService;
+use App\Http\Controllers\RelationalResourceController;
+use App\Http\Transformers\V0\ItemTransformer;
+
+class StatusEffectItemController extends RelationalResourceController
+{
+    /**
+     * Create a new StatusEffectItemController instance.
+     *
+     * @param StatusEffectService $statusEffectService The Service that will process the request
+     * @param ItemTransformer     $itemTransformer     The Transformer that will standardize the response
+     */
+    public function __construct(StatusEffectService $statusEffectService, ItemTransformer $itemTransformer)
+    {
+        $this->service = $statusEffectService;
+        $this->transformer = $itemTransformer;
+        $this->relation = 'items';
+    }
+}

--- a/app/Http/Transformers/V0/ItemTransformer.php
+++ b/app/Http/Transformers/V0/ItemTransformer.php
@@ -15,7 +15,7 @@ class ItemTransformer extends RecordTransformer
      */
     public function transformRecord(array $record): array
     {
-        return [
+        $data = [
             'id' => $record['id'],
             'slug' => $record['slug'],
             'position' => $record['position'],
@@ -31,5 +31,23 @@ class ItemTransformer extends RecordTransformer
             'used_in_battle' => $record['used_in_battle'],
             'notes' => $record['notes'],
         ];
+
+        if (array_key_exists('status_effects', $record)) {
+            $data['status_effects'] = $record['status_effects']
+                ? $this->getStatusEffectTransformer()->transformCollection($record['status_effects'])
+                : null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Create a new StatusEffectTransformer instance.
+     *
+     * @return StatusEffectTransformer
+     */
+    protected function getStatusEffectTransformer(): StatusEffectTransformer
+    {
+        return new StatusEffectTransformer();
     }
 }

--- a/app/Http/Transformers/V0/StatusEffectTransformer.php
+++ b/app/Http/Transformers/V0/StatusEffectTransformer.php
@@ -15,12 +15,30 @@ class StatusEffectTransformer extends RecordTransformer
      */
     public function transformRecord(array $record): array
     {
-        return [
+        $data = [
             'id' => $record['id'],
             'sort_id' => $record['sort_id'],
             'name' => $record['name'],
             'type' => $record['type'],
             'description' => $record['description'],
         ];
+
+        if (array_key_exists('items', $record)) {
+            $data['items'] = $record['items']
+                ? $this->getItemTransformer()->transformCollection($record['items'])
+                : null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Create a new ItemTransformer instance.
+     *
+     * @return ItemTransformer
+     */
+    protected function getItemTransformer(): ItemTransformer
+    {
+        return new ItemTransformer();
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Item extends SearchableModel
 {
@@ -49,6 +50,7 @@ class Item extends SearchableModel
         'used_in_menu',
         'used_in_battle',
         'notes',
+        'statusEffects',
     ];
 
     /**
@@ -115,6 +117,22 @@ class Item extends SearchableModel
         'notes',
     ];
 
+    /**
+     * The relations that are available to include with the resource.
+     *
+     * @var array<int, string>
+     */
+    protected $availableIncludes = [
+        'statusEffects',
+    ];
+
+    /**
+     * The default relations to include with the resource.
+     *
+     * @var array<int, string>
+     */
+    protected $defaultIncludes = [];
+
     /*
      * Get the route key for the model.
      *
@@ -123,5 +141,15 @@ class Item extends SearchableModel
     public function getRouteKeyName(): string
     {
         return 'slug';
+    }
+
+    /**
+     * The status effects that are associated with the item.
+     * 
+     * @return BelongsToMany<StatusEffect>
+     */
+    public function statusEffects(): BelongsToMany
+    {
+        return $this->belongsToMany(StatusEffect::class);
     }
 }

--- a/app/Models/StatusEffect.php
+++ b/app/Models/StatusEffect.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class StatusEffect extends SearchableModel
 {
@@ -40,6 +41,7 @@ class StatusEffect extends SearchableModel
         'name',
         'type',
         'description',
+        'items',
     ];
 
     /**
@@ -77,6 +79,22 @@ class StatusEffect extends SearchableModel
         'description',
     ];
 
+    /**
+     * The relations that are available to include with the resource.
+     *
+     * @var array<int, string>
+     */
+    protected $availableIncludes = [
+        'items',
+    ];
+
+    /**
+     * The default relations to include with the resource.
+     *
+     * @var array<int, string>
+     */
+    protected $defaultIncludes = [];
+
     /*
      * Get the route key for the model.
      *
@@ -85,5 +103,15 @@ class StatusEffect extends SearchableModel
     public function getRouteKeyName(): string
     {
         return 'name';
+    }
+
+    /**
+     * The items that are associated with the status effect.
+     * 
+     * @return BelongsToMany<Item>
+     */
+    public function items(): BelongsToMany
+    {
+        return $this->belongsToMany(Item::class);
     }
 }

--- a/database/migrations/2023_03_10_044437_create_item_status_effect_table.php
+++ b/database/migrations/2023_03_10_044437_create_item_status_effect_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('item_status_effect', function (Blueprint $table) {
+            $table->uuid('item_id');
+            $table->uuid('status_effect_id');
+
+            $table->unique(['item_id', 'status_effect_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('items_status_effects');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ElementsTableSeeder::class);
         $this->call(ItemsTableSeeder::class);
         $this->call(LocationsTableSeeder::class);
+        $this->call(ItemStatusEffectTableSeeder::class);
     }
 }

--- a/database/seeders/ItemStatusEffectTableSeeder.php
+++ b/database/seeders/ItemStatusEffectTableSeeder.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Item;
+use App\Models\StatusEffect;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ItemStatusEffectTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $itemsMap = [
+            [
+                'slug' => 'phoenix-down',
+                'status-effects' => [
+                    'death',
+                ],
+            ],
+            [
+                'slug' => 'mega-phoenix',
+                'status-effects' => [
+                    'death',
+                ],
+            ],
+            [
+                'slug' => 'elixir',
+                'status-effects' => [
+                    'poison',
+                    'petrify',
+                    'darkness',
+                    'silence',
+                    'berserk',
+                    'sleep',
+                    'slow',
+                    'stop',
+                    'curse',
+                    'doom',
+                    'petrifying',
+                    'confuse',
+                    'vit 0',
+                ],
+            ],
+            [
+                'slug' => 'megalixir',
+                'status-effects' => [
+                    'poison',
+                    'petrify',
+                    'darkness',
+                    'silence',
+                    'berserk',
+                    'sleep',
+                    'slow',
+                    'stop',
+                    'curse',
+                    'doom',
+                    'petrifying',
+                    'confuse',
+                    'vit 0',
+                ],
+            ],
+            [
+                'slug' => 'antidote',
+                'status-effects' => [
+                    'poison',
+                ],
+            ],
+            [
+                'slug' => 'soft',
+                'status-effects' => [
+                    'petrify',
+                    'petrifying',
+                ],
+            ],
+            [
+                'slug' => 'eye-drops',
+                'status-effects' => [
+                    'darkness',
+                ],
+            ],
+            [
+                'slug' => 'echo-screen',
+                'status-effects' => [
+                    'silence',
+                ],
+            ],
+            [
+                'slug' => 'holy-water',
+                'status-effects' => [
+                    'zombie',
+                    'curse',
+                ],
+            ],
+            [
+                'slug' => 'remedy',
+                'status-effects' => [
+                    'poison',
+                    'petrify',
+                    'darkness',
+                    'silence',
+                    'berserk',
+                    'zombie',
+                    'sleep',
+                    'curse',
+                    'petrifying',
+                    'confuse',
+                ],
+            ],
+            [
+                'slug' => 'remedy-plus',
+                'status-effects' => [
+                    'poison',
+                    'petrify',
+                    'darkness',
+                    'silence',
+                    'berserk',
+                    'zombie',
+                    'sleep',
+                    'slow',
+                    'stop',
+                    'curse',
+                    'doom',
+                    'petrifying',
+                    'confuse',
+                ],
+            ],
+            [
+                'slug' => 'hero-trial',
+                'status-effects' => [
+                    'invincible',
+                ],
+            ],
+            [
+                'slug' => 'hero',
+                'status-effects' => [
+                    'invincible',
+                ],
+            ],
+            [
+                'slug' => 'holy-war-trial',
+                'status-effects' => [
+                    'invincible',
+                ],
+            ],
+            [
+                'slug' => 'holy-war',
+                'status-effects' => [
+                    'invincible',
+                ],
+            ],
+        ];
+
+        $dbItems = Item::all();
+        $dbStatusEffects = StatusEffect::all();
+        $recordsToInsert = [];
+
+        foreach ($itemsMap as $item) {
+            $matchedItem = $dbItems->filter(function ($i) use ($item) {
+                return $i['slug'] === $item['slug'];
+            })->first();
+
+            foreach ($item['status-effects'] as $statusEffectName) {
+                $matchedStatusEffect = $dbStatusEffects->filter(function ($i) use ($statusEffectName) {
+                    return $i['name'] === $statusEffectName;
+                })->first();
+
+                $recordsToInsert[] = [
+                    'item_id' => $matchedItem->id,
+                    'status_effect_id' => $matchedStatusEffect->id,
+                ];
+            }
+        }
+
+        DB::table('item_status_effect')->insert($recordsToInsert);
+    }
+}

--- a/routes/v0.php
+++ b/routes/v0.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\V0\ElementController;
 use App\Http\Controllers\V0\HealthCheckController;
 use App\Http\Controllers\V0\ItemController;
+use App\Http\Controllers\V0\ItemStatusEffectController;
 use App\Http\Controllers\V0\LocationController;
 use App\Http\Controllers\V0\LocationLocationController;
 use App\Http\Controllers\V0\SearchController;
@@ -10,6 +11,7 @@ use App\Http\Controllers\V0\SeedRankController;
 use App\Http\Controllers\V0\SeedTestController;
 use App\Http\Controllers\V0\SeedTestTestQuestionController;
 use App\Http\Controllers\V0\StatusEffectController;
+use App\Http\Controllers\V0\StatusEffectItemController;
 use App\Http\Controllers\V0\TestQuestionController;
 use Illuminate\Support\Facades\Route;
 
@@ -33,12 +35,14 @@ Route::group(['middleware' => 'relations.sanitize'], function () {
 
     Route::get('/status-effects/')->uses([StatusEffectController::class, 'index']);
     Route::get('/status-effects/{id}')->uses([StatusEffectController::class, 'show']);
+    Route::get('/status-effects/{id}/items')->uses([StatusEffectItemController::class, 'index']);
 
     Route::get('/elements/')->uses([ElementController::class, 'index']);
     Route::get('/elements/{id}')->uses([ElementController::class, 'show']);
 
     Route::get('/items/')->uses([ItemController::class, 'index']);
     Route::get('/items/{id}')->uses([ItemController::class, 'show']);
+    Route::get('/items/{id}/status-effects')->uses([ItemStatusEffectController::class, 'index']);
 
     Route::get('/locations/')->uses([LocationController::class, 'index']);
     Route::get('/locations/{id}')->uses([LocationController::class, 'show']);

--- a/tests/Feature/Endpoints/V0/ElementEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/ElementEndpointTest.php
@@ -16,7 +16,7 @@ class ElementEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/HealthCheckEndpointTest.php
@@ -12,7 +12,7 @@ class HealthCheckEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 
@@ -60,11 +60,36 @@ class HealthCheckEndpointTest extends TestCase
                             'url_parameters' => [],
                             'query_parameters' => [],
                         ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/seed-ranks/{seed-rank}",
+                            'url_parameters' => [
+                                '{seed-rank}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'rank'],
+                                ],
+                            ],
+                            'query_parameters' => [],
+                        ],
                     ],
                     'seed_tests' => [
                         [
                             'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests",
                             'url_parameters' => [],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['test-questions'],
+                                ],
+                            ],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/seed-tests/{seed-test}",
+                            'url_parameters' => [
+                                '{seed-test}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'level'],
+                                ],
+                            ],
                             'query_parameters' => [
                                 'include' => [
                                     'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
@@ -99,18 +124,78 @@ class HealthCheckEndpointTest extends TestCase
                                 ],
                             ],
                         ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/test-questions/{test-question}",
+                            'url_parameters' => [
+                                '{test-question}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id'],
+                                ],
+                            ],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['seed-test'],
+                                ],
+                            ],
+                        ],
                     ],
                     'status_effects' => [
                         [
                             'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects",
                             'url_parameters' => [],
-                            'query_parameters' => [],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['items'],
+                                ]
+                            ],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects/{status-effect}",
+                            'url_parameters' => [
+                                '{status-effect}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'name'],
+                                ],
+                            ],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['items'],
+                                ]
+                            ],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/status-effects/{status-effect}/items",
+                            'url_parameters' => [
+                                '{status-effect}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'name'],
+                                ],
+                            ],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['status-effects'],
+                                ]
+                            ],
                         ],
                     ],
                     'elements' => [
                         [
                             'url' => "{$baseUrl}/v{$currentApiVersion}/elements",
                             'url_parameters' => [],
+                            'query_parameters' => [],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/elements/{element}",
+                            'url_parameters' => [
+                                '{element}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'name'],
+                                ],
+                            ],
                             'query_parameters' => [],
                         ],
                     ],
@@ -120,6 +205,31 @@ class HealthCheckEndpointTest extends TestCase
                             'url_parameters' => [],
                             'query_parameters' => [],
                         ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/items/{item}",
+                            'url_parameters' => [
+                                '{item}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'slug'],
+                                ],
+                            ],
+                            'query_parameters' => [],
+                        ],
+                        [
+                            'url' => "{$baseUrl}/v{$currentApiVersion}/items/{item}/status-effects",
+                            'url_parameters' => [
+                                '{item}' => [
+                                    'description' => 'The unique identifier associated with the record. Options indicate the keys on the record where the associated value may be used as the identifier.',
+                                    'options' => ['id', 'slug'],
+                                ],
+                            ],
+                            'query_parameters' => [
+                                'include' => [
+                                    'description' => 'Include the specified relations with the results. Options may be formatted as camelCase, snake_case, or kebab-case.',
+                                    'options' => ['items'],
+                                ]
+                            ],
+                        ]
                     ],
                     'locations' => [
                         [
@@ -156,7 +266,7 @@ class HealthCheckEndpointTest extends TestCase
                             ],
                         ],
                     ],
-                ],
+                ]
             ],
         ]);
     }

--- a/tests/Feature/Endpoints/V0/ItemsStatusEffectsEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/ItemsStatusEffectsEndpointTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\Item;
+use App\Models\StatusEffect;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Tests\TestCase;
+
+class ItemsStatusEffectsEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddleware = [
+        ThrottleRequestsWithRedis::class,
+    ];
+
+    /** @test */
+    public function it_will_return_a_list_of_status_effects_related_to_an_item_using_the_id_key(): void
+    {
+        $item = Item::factory()
+            ->has(StatusEffect::factory()->count(3))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/items/{$item['id']}/status-effects");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(3, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_a_list_of_status_effects_related_to_an_item_using_the_slug_key(): void
+    {
+        $item = Item::factory()
+            ->has(StatusEffect::factory()->count(3))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/items/{$item['slug']}/status-effects");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(3, 'data');
+    }
+}

--- a/tests/Feature/Endpoints/V0/LocationEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/LocationEndpointTest.php
@@ -17,7 +17,7 @@ class LocationEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/LocationLocationEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/LocationLocationEndpointTest.php
@@ -16,7 +16,7 @@ class LocationLocationEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/SearchEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SearchEndpointTest.php
@@ -22,7 +22,7 @@ class SearchEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedRankEndpointTest.php
@@ -16,7 +16,7 @@ class SeedRankEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestEndpointTest.php
@@ -18,7 +18,7 @@ class SeedTestEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/SeedTestTestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/SeedTestTestQuestionEndpointTest.php
@@ -17,7 +17,7 @@ class SeedTestTestQuestionEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/StatusEffectEndpointTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Endpoints\V0;
 
+use App\Http\Transformers\V0\ItemTransformer;
+use App\Models\Item;
 use App\Models\StatusEffect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
@@ -16,7 +18,7 @@ class StatusEffectEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 
@@ -98,6 +100,65 @@ class StatusEffectEndpointTest extends TestCase
             'status_code' => 404,
             'errors' => [
                 'message' => 'The requested record could not be found.',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_load_the_items_relation_on_a_list_of_status_effects(): void
+    {
+        StatusEffect::factory()
+            ->count(10)
+            ->has(Item::factory()->count(10))
+            ->create();
+
+        $response = $this->get('/v0/status-effects?include=items');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data' => [
+                [
+                    'items' => [
+                        // An array of Items on each record...
+                    ],
+                ],
+            ],
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(10, 'data');
+    }
+
+    /** @test */
+    public function it_can_load_the_items_relation_on_an_individual_status_effect(): void
+    {
+        $statusEffect = StatusEffect::factory()
+            ->has(Item::factory()->count(10))
+            ->create()
+            ->load('items')
+            ->toArray();
+
+        $itemTransformer = $this->app->make(ItemTransformer::class);
+        $response = $this->get("/v0/status-effects/{$statusEffect['id']}?include=items");
+
+        $response->assertStatus(200);
+        $response->assertExactJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+            'data' => [
+                'id' => $statusEffect['id'],
+                'sort_id' => $statusEffect['sort_id'],
+                'name' => $statusEffect['name'],
+                'type' => $statusEffect['type'],
+                'description' => $statusEffect['description'],
+                'items' => $itemTransformer->transformCollection($statusEffect['items']),
             ],
         ]);
     }

--- a/tests/Feature/Endpoints/V0/StatusEffectsItemsEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/StatusEffectsItemsEndpointTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Endpoints\V0;
+
+use App\Models\Item;
+use App\Models\StatusEffect;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Tests\TestCase;
+
+class StatusEffectsItemsEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * The middleware to exclude when running tests.
+     *
+     * @var array<int, class-string>
+     */
+    protected $excludedMiddleware = [
+        ThrottleRequestsWithRedis::class,
+    ];
+
+    /** @test */
+    public function it_will_return_a_list_of_items_related_to_a_status_effect_using_the_id_key(): void
+    {
+        $statusEffect = StatusEffect::factory()
+            ->has(Item::factory()->count(3))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/status-effects/{$statusEffect['id']}/items");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(3, 'data');
+    }
+
+    /** @test */
+    public function it_will_return_a_list_of_itemss_related_to_a_status_effect_using_the_name_key(): void
+    {
+        $statusEffect = StatusEffect::factory()
+            ->has(Item::factory()->count(3))
+            ->create()
+            ->toArray();
+
+        $response = $this->get("/v0/status-effects/{$statusEffect['name']}/items");
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'success',
+            'message',
+            'status_code',
+            'data',
+        ]);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Successfully retrieved data.',
+            'status_code' => 200,
+        ]);
+        $response->assertJsonCount(3, 'data');
+    }
+}

--- a/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
+++ b/tests/Feature/Endpoints/V0/TestQuestionEndpointTest.php
@@ -18,7 +18,7 @@ class TestQuestionEndpointTest extends TestCase
      *
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [
+    protected $excludedMiddleware = [
         ThrottleRequestsWithRedis::class,
     ];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ abstract class TestCase extends BaseTestCase
      * 
      * @var array<int, class-string>
      */
-    protected $excludedMiddlware = [];
+    protected $excludedMiddleware = [];
 
     /**
      * Setup the test environment.
@@ -26,6 +26,6 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->withoutMiddleware($this->excludedMiddlware);
+        $this->withoutMiddleware($this->excludedMiddleware);
     }
 }

--- a/tests/Unit/Models/ItemTest.php
+++ b/tests/Unit/Models/ItemTest.php
@@ -46,6 +46,7 @@ class ItemTest extends TestCase
             'used_in_menu',
             'used_in_battle',
             'notes',
+            'statusEffects',
         ];
 
         $this->assertEquals($visibleFields, $item->getVisible());
@@ -99,6 +100,28 @@ class ItemTest extends TestCase
         ];
 
         $this->assertEquals($expected, $item->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource(): void
+    {
+        $item = new Item();
+
+        $expected = [
+            'statusEffects',
+        ];
+
+        $this->assertEquals($expected, $item->getAvailableIncludes());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource(): void
+    {
+        $item = new Item();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $item->getDefaultIncludes());
     }
 
     /** @test */

--- a/tests/Unit/Models/StatusEffectTest.php
+++ b/tests/Unit/Models/StatusEffectTest.php
@@ -37,6 +37,7 @@ class StatusEffectTest extends TestCase
             'name',
             'type',
             'description',
+            'items',
         ];
 
         $this->assertEquals($visibleFields, $statusEffect->getVisible());
@@ -70,6 +71,28 @@ class StatusEffectTest extends TestCase
         ];
 
         $this->assertEquals($expected, $statusEffect->getSearchableFields());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_relations_that_are_available_to_include_with_the_resource(): void
+    {
+        $statusEffect = new StatusEffect();
+
+        $expected = [
+            'items',
+        ];
+
+        $this->assertEquals($expected, $statusEffect->getAvailableIncludes());
+    }
+
+    /** @test */
+    public function it_explicitly_defines_the_default_relations_to_include_with_the_resource(): void
+    {
+        $statusEffect = new StatusEffect();
+
+        $expected = [];
+
+        $this->assertEquals($expected, $statusEffect->getDefaultIncludes());
     }
 
     /** @test */


### PR DESCRIPTION
Includes the relations for Items and Status Effects. This includes endpoints for each of these resources, as well as allows the relation to be included via query parameters.